### PR TITLE
fix error numeration

### DIFF
--- a/Poliedro.Billing.Infraestructure.External.Plemsi/Adapter/FE/Retail/FERetailService.cs
+++ b/Poliedro.Billing.Infraestructure.External.Plemsi/Adapter/FE/Retail/FERetailService.cs
@@ -58,7 +58,7 @@ IConfiguration config) : IFERetailService
                     int InvoiceNumber = int.Parse(item.invoice[^4..]);
                     int invoice = await invoiceLastRepository.GetInvoiceLastAsync(connectionString, clientItem, cancellationToken);
                     if (invoice == 0) return FERetailResponse;
-                    if (invoice == 1) invoice = clientItem.DianResolution.InitialRange;
+                    if (invoice == 1) invoice = clientItem.DianResolution.CurrentlyNumber + 1;
                     if (invoice < clientItem.DianResolution.InitialRange) invoice = clientItem.DianResolution.InitialRange;
                     DateTime date = DateTime.Now;
                     string formattedDate = date.ToString("yyyy-MM-dd");
@@ -173,7 +173,7 @@ IConfiguration config) : IFERetailService
 
 
                         await updateCurrentlyNumber.UpdateCurrentlyNumberAsync(
-                           new ParametersCurrentlyNumber(invoice, item.transaction_date, clientItem.ResolutionId),
+                           new ParametersCurrentlyNumber(invoice, date.ToString(), clientItem.ResolutionId),
                            cancellationToken);
 
 
@@ -198,7 +198,7 @@ IConfiguration config) : IFERetailService
                                     item.invoice);
 
                                 await updateCurrentlyNumber.UpdateCurrentlyNumberAsync(
-                                    new ParametersCurrentlyNumber(invoice, item.transaction_date, clientItem.ResolutionId),
+                                    new ParametersCurrentlyNumber(invoice, date.ToString(), clientItem.ResolutionId),
                                     cancellationToken);
                             }
                         }


### PR DESCRIPTION
## Summary by Sourcery

Fix invoice numbering logic and standardize date usage when updating the current invoice number

Bug Fixes:
- Use DianResolution.CurrentlyNumber + 1 rather than InitialRange for the first invoice when last invoice is 1
- Replace item.transaction_date with the current date string in updateCurrentlyNumber.UpdateCurrentlyNumberAsync calls