### PR TITLE
add health

### DIFF
--- a/Poliedro.Billing.Api/Poliedro.Billing.Api.csproj
+++ b/Poliedro.Billing.Api/Poliedro.Billing.Api.csproj
@@ -9,6 +9,12 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="AspNetCore.HealthChecks.MySql" Version="9.0.0" />
+    <PackageReference Include="AspNetCore.HealthChecks.UI" Version="9.0.0" />
+    <PackageReference Include="AspNetCore.HealthChecks.UI.Client" Version="9.0.0" />
+    <PackageReference Include="AspNetCore.HealthChecks.UI.Core" Version="9.0.0" />
+    <PackageReference Include="AspNetCore.HealthChecks.UI.InMemory.Storage" Version="9.0.0" />
+    <PackageReference Include="AspNetCore.HealthChecks.UI.MySql.Storage" Version="9.0.0" />
     <PackageReference Include="FluentValidation.AspNetCore" Version="11.3.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.2.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="8.0.6">

--- a/Poliedro.Billing.Api/Program.cs
+++ b/Poliedro.Billing.Api/Program.cs
@@ -20,6 +20,9 @@ using Poliedro.Billing.Infraestructure.Persistence.Mysql.Adapter;
 using Poliedro.Billing.Infraestructure.Persistence.Mysql.Context;
 using Poliedro.Billing.Infraestructure.Persistence.Mysql.Context;
 using WorkerServiceBilling;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Diagnostics.HealthChecks;
+using HealthChecks.UI.Client;
 
 var builder = WebApplication.CreateBuilder(args);
 var config = builder.Configuration;
@@ -102,8 +105,18 @@ builder.Services.AddHostedService<Worker>();
 builder.Services.AddValidatorsFromAssemblyContaining<CreateCreditNoteCommandValidator>();
 builder.Services.AddTransient(typeof(IPipelineBehavior<,>), typeof(ValidationBehaviour<,>));
 builder.Services.AddSingleton<IMessageProvider, MessageProvider>();
-var app = builder.Build();
+builder.Services.AddHealthChecks()
+    .AddMySql(builder.Configuration.GetConnectionString("MysqlConnection"), name: "sql", tags: ["ready"]);
 
+var app = builder.Build();
+app.MapHealthChecks("/health", new HealthCheckOptions()
+{
+    ResponseWriter = UIResponseWriter.WriteHealthCheckUIResponse
+});
+app.MapHealthChecksUI(options =>
+{
+    options.UIPath = "/health-ui";
+});
 app.UseCors("PoliedroBilling");
 
 app.UseSwagger();


### PR DESCRIPTION
## Summary by Sourcery

Add ASP.NET Core health checks with MySQL readiness probe and a UI dashboard

New Features:
- Expose /health and /health-ui endpoints for service health monitoring
- Add MySQL readiness probe via ASP.NET Core health checks

Build:
- Include HealthChecks.UI.Client and AspNetCore.HealthChecks.MySql packages in project dependencies