### PR TITLE
feat(HeadNote and FootNote ADD).

### DIFF
--- a/Poliedro.Billing.Application/Billing/Services/Selectors/Plemsi/PrepareBillingFE.cs
+++ b/Poliedro.Billing.Application/Billing/Services/Selectors/Plemsi/PrepareBillingFE.cs
@@ -218,8 +218,8 @@ namespace Poliedro.Billing.Application.Billing.Services.Selectors.Plemsi
                         items = invoice.ItemElectronicEntity,
                         resolution = clientInfo.ResolucionNumber,
                         resolutionText = clientInfo.Descripcion,
-                        head_note = invoice.Number,
-                        foot_note = invoice.Number,
+                        head_note = string.IsNullOrWhiteSpace(clientInfo.HeadNote) ? invoice.Number : clientInfo.HeadNote,
+                        foot_note = string.IsNullOrWhiteSpace(clientInfo.FootNote) ? invoice.Number : clientInfo.FootNote,
                         notes = $"Fecha de la factura:{invoice.TransactionDate}",
 
 

--- a/Poliedro.Billing.Domain/Billing/BillingInfoClient.cs
+++ b/Poliedro.Billing.Domain/Billing/BillingInfoClient.cs
@@ -15,6 +15,7 @@ public class BillingInfoClient
     public required string Descripcion { get; set; }
     public required int CurrentlyNumber { get; set; }
     public required int MultipleResolution { get; set; }
-
+    public string? HeadNote { get; set; }
+    public string? FootNote { get; set; }
     public required int ResolutionId { get; set; }
 }

--- a/Poliedro.Billing.Domain/Client/Entities/ClientEntity.cs
+++ b/Poliedro.Billing.Domain/Client/Entities/ClientEntity.cs
@@ -21,4 +21,6 @@ public class ClientEntity
     public int Automatic { get; set; } = default!;
     public int MultipleResolution { get; set; } = default!;
     public string Email { get; set; } = string.Empty;
+    public string HeadNote {  get; set; } = string.Empty;
+    public string FootNote { get; set; } = string.Empty;
 }

--- a/Poliedro.Billing.Infraestructure.External.Plemsi/Adapter/Billing/Impl/BillingGetInfoClient.cs
+++ b/Poliedro.Billing.Infraestructure.External.Plemsi/Adapter/Billing/Impl/BillingGetInfoClient.cs
@@ -24,7 +24,9 @@ public class BillingGetInfoClient : IBillingGetInfoClient
             Descripcion = clientEntity.DianResolution.Description,
             CurrentlyNumber = clientEntity.DianResolution.CurrentlyNumber,
             MultipleResolution = clientEntity.MultipleResolution,
-            ResolutionId = clientEntity.ResolutionId
+            ResolutionId = clientEntity.ResolutionId,
+            HeadNote = clientEntity.HeadNote,
+            FootNote = clientEntity.FootNote
 
         };
 

--- a/Poliedro.Billing.Infraestructure.Persistence.Mysql/EntityFramework/EntityConfigurations/ClientBillingElectronicConfiguration.cs
+++ b/Poliedro.Billing.Infraestructure.Persistence.Mysql/EntityFramework/EntityConfigurations/ClientBillingElectronicConfiguration.cs
@@ -21,8 +21,10 @@ namespace Poliedro.Billing.Infraestructure.Persistence.Mysql.EntityFramework.Ent
             builder.Property(x => x.ApiKey).HasColumnName("apikey");
             builder.Property(x => x.Automatic).HasColumnName("automatic");
             builder.Property(x => x.MultipleResolution).HasColumnName("multiple_resolution");
-            builder.Property(x => x.Email).HasColumnName("email")
-                .HasMaxLength(100)
+            builder.Property(x => x.Email).HasColumnName("email");
+            builder.Property(x => x.HeadNote).HasColumnName("head_note");
+            builder.Property(x => x.FootNote).HasColumnName("foot_note")
+                .HasMaxLength(1000)
                 .IsRequired(false);
             builder.HasOne(x => x.Server)
                 .WithMany(x => x.clientsBillingElectronic)


### PR DESCRIPTION
## Summary by Sourcery

Add support for custom head and foot notes in client billing by extending domain entities, persistence configuration, and external adapters, and update invoice preparation to respect these notes with a fallback to the invoice number.

New Features:
- Add HeadNote and FootNote properties to ClientEntity and BillingInfoClient domain models
- Map head_note and foot_note columns in EF Core configuration and include them in the Plemsi billing adapter

Enhancements:
- Update billing preparation to use client-specific head and foot notes with invoice number fallback
- Remove strict max length constraint from the Email column mapping