### PR TITLE
bug-fixed(dv-cc)

### DIFF
--- a/Poliedro.Billing.Application/Billing/Services/Selectors/Plemsi/PrepareBillingFE.cs
+++ b/Poliedro.Billing.Application/Billing/Services/Selectors/Plemsi/PrepareBillingFE.cs
@@ -157,7 +157,7 @@ namespace Poliedro.Billing.Application.Billing.Services.Selectors.Plemsi
                     
                     if (checkDigit == "error")
                     {
-                        identification = _config["CosumerFinal:identification"];
+                        invoice.CustomerEntity.IdentificationNumber = _config["CosumerFinal:identification"];
                         checkDigit = _config["CosumerFinal:dv"];
                     }
 


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Assign the consumer final identification number to invoice.CustomerEntity.IdentificationNumber instead of a local variable when check digit is "error"