### PR TITLE
Upgrade to net10

### DIFF
--- a/.github/upgrades/dotnet-upgrade-plan.md
+++ b/.github/upgrades/dotnet-upgrade-plan.md
@@ -1,0 +1,117 @@
+# .NET 10 Upgrade Plan
+
+## Execution Steps
+
+Execute steps below sequentially one by one in the order they are listed.
+
+1. Validate that a .NET 10 SDK required for this upgrade is installed on the machine and if not, help to get it installed.
+2. Ensure that the SDK version specified in global.json files is compatible with the .NET 10 upgrade.
+3. Upgrade Poliedro.Billing.Domain\Poliedro.Billing.Domain.csproj
+4. Upgrade Poliedro.Billing.Application\Poliedro.Billing.Application.csproj
+5. Upgrade Poliedro.Billing.Infraestructure.Persistence.Mysql\Poliedro.Billing.Infraestructure.Persistence.Mysql.csproj
+6. Upgrade Poliedro.Billing.Infraestructure.External.TNS\Poliedro.Billing.Infraestructure.External.TNS.csproj
+7. Upgrade Poliedro.Billing.Infraestructure.External.Plemsi\Poliedro.Billing.Infraestructure.External.Plemsi.csproj
+8. Upgrade Poliedro.Billing.Infraestructure.External.Siigo\Poliedro.Billing.Infraestructure.External.Siigo.csproj
+9. Upgrade Poliedro.Billing.Domain.Test\Poliedro.Billing.Domain.Test.csproj
+10. Upgrade Poliedro.Billing.Api.Tests\Poliedro.Billing.Api.Tests.csproj
+11. Upgrade Poliedro.Billing.Api\Poliedro.Billing.Api.csproj
+
+## Settings
+
+This section contains settings and data used by execution steps.
+
+### Aggregate NuGet packages modifications across all projects
+
+NuGet packages used across all selected projects or their dependencies that need version update in projects that reference them.
+
+| Package Name                                        | Current Version | New Version | Description                                                      |
+|:----------------------------------------------------|:---------------:|:-----------:|:-----------------------------------------------------------------|
+| FluentValidation.AspNetCore                         | 11.3.0          | 11.3.1      | Package is deprecated and should be updated                      |
+| Microsoft.AspNetCore.Mvc                            | 2.2.0           |             | Deprecated package - functionality included with framework or replace with 2.3.0 |
+| Microsoft.EntityFrameworkCore                       | 8.0.1           | 10.0.0      | Recommended for .NET 10                                          |
+| Microsoft.EntityFrameworkCore.Tools                 | 8.0.1; 8.0.6    | 10.0.0      | Recommended for .NET 10                                          |
+| Microsoft.Extensions.Configuration                  | 8.0.0; 9.0.0    | 10.0.0      | Recommended for .NET 10                                          |
+| Microsoft.Extensions.Configuration.Abstractions     | 9.0.0           | 10.0.0      | Recommended for .NET 10                                          |
+| Microsoft.Extensions.DependencyInjection.Abstractions | 8.0.1; 8.0.6  | 10.0.0      | Recommended for .NET 10                                          |
+| Newtonsoft.Json                                     | 13.0.1          | 13.0.4      | Recommended for .NET 10                                          |
+
+### Project upgrade details
+
+This section contains details about each project upgrade and modifications that need to be done in the project.
+
+#### Poliedro.Billing.Domain modifications
+
+Project properties changes:
+  - Target framework should be changed from `net8.0` to `net10.0`
+
+NuGet packages changes:
+  - Microsoft.Extensions.Configuration.Abstractions should be updated from `9.0.0` to `10.0.0` (*recommended for .NET 10*)
+  - Microsoft.AspNetCore.Mvc should be removed or replaced with version `2.3.0` (*deprecated package*)
+
+#### Poliedro.Billing.Application modifications
+
+Project properties changes:
+  - Target framework should be changed from `net8.0` to `net10.0`
+
+NuGet packages changes:
+  - Microsoft.Extensions.DependencyInjection.Abstractions should be updated from `8.0.1` to `10.0.0` (*recommended for .NET 10*)
+  - Microsoft.AspNetCore.Mvc should be removed or replaced with version `2.3.0` (*deprecated package*)
+
+#### Poliedro.Billing.Infraestructure.Persistence.Mysql modifications
+
+Project properties changes:
+  - Target framework should be changed from `net8.0` to `net10.0`
+
+NuGet packages changes:
+  - Microsoft.EntityFrameworkCore should be updated from `8.0.1` to `10.0.0` (*recommended for .NET 10*)
+  - Microsoft.EntityFrameworkCore.Tools should be updated from `8.0.1` to `10.0.0` (*recommended for .NET 10*)
+  - Microsoft.AspNetCore.Mvc should be removed or replaced with version `2.3.0` (*deprecated package*)
+
+#### Poliedro.Billing.Infraestructure.External.TNS modifications
+
+Project properties changes:
+  - Target framework should be changed from `net8.0` to `net10.0`
+
+NuGet packages changes:
+  - Microsoft.Extensions.Configuration should be updated from `8.0.0` to `10.0.0` (*recommended for .NET 10*)
+  - Microsoft.AspNetCore.Mvc should be removed or replaced with version `2.3.0` (*deprecated package*)
+
+#### Poliedro.Billing.Infraestructure.External.Plemsi modifications
+
+Project properties changes:
+  - Target framework should be changed from `net8.0` to `net10.0`
+
+NuGet packages changes:
+  - Microsoft.Extensions.Configuration should be updated from `9.0.0` to `10.0.0` (*recommended for .NET 10*)
+  - Microsoft.Extensions.DependencyInjection.Abstractions should be updated from `8.0.1` to `10.0.0` (*recommended for .NET 10*)
+  - Newtonsoft.Json should be updated from `13.0.1` to `13.0.4` (*recommended for .NET 10*)
+
+#### Poliedro.Billing.Infraestructure.External.Siigo modifications
+
+Project properties changes:
+  - Target framework should be changed from `net8.0` to `net10.0`
+
+NuGet packages changes:
+  - Microsoft.Extensions.Configuration should be updated from `8.0.0` to `10.0.0` (*recommended for .NET 10*)
+  - Microsoft.AspNetCore.Mvc should be removed or replaced with version `2.3.0` (*deprecated package*)
+
+#### Poliedro.Billing.Domain.Test modifications
+
+Project properties changes:
+  - Target framework should be changed from `net8.0` to `net10.0`
+
+#### Poliedro.Billing.Api.Tests modifications
+
+Project properties changes:
+  - Target framework should be changed from `net8.0` to `net10.0`
+
+#### Poliedro.Billing.Api modifications
+
+Project properties changes:
+  - Target framework should be changed from `net8.0` to `net10.0`
+
+NuGet packages changes:
+  - Microsoft.EntityFrameworkCore.Tools should be updated from `8.0.6` to `10.0.0` (*recommended for .NET 10*)
+  - Microsoft.Extensions.DependencyInjection.Abstractions should be updated from `8.0.6` to `10.0.0` (*recommended for .NET 10*)
+  - FluentValidation.AspNetCore should be updated from `11.3.0` to `11.3.1` (*deprecated package*)
+  - Microsoft.AspNetCore.Mvc functionality is included with framework reference (*remove package*)

--- a/.github/upgrades/dotnet-upgrade-report.md
+++ b/.github/upgrades/dotnet-upgrade-report.md
@@ -27,6 +27,14 @@
 | Microsoft.Extensions.DependencyInjection.Abstractions | 8.0.1, 8.0.6 | 10.0.0      | ad3ccf64, 21ee36c9, ecf1f65e                      |
 | Newtonsoft.Json                                     | 13.0.1         | 13.0.4      | 21ee36c9                                          |
 
+## Docker and CI/CD Updates
+
+| File                                 | Old Version | New Version | Description                                       |
+|:-------------------------------------|:-----------:|:-----------:|:--------------------------------------------------|
+| Dockerfile                           | 8.0         | 10.0        | Updated ASP.NET and SDK images to .NET 10         |
+| WorkerServiceBilling/Dockerfile      | 8.0         | 10.0        | Updated runtime and SDK images to .NET 10         |
+| .github/workflows/main.yml           | 8.0.x       | 10.0.x      | Updated dotnet-version to use .NET 10 SDK         |
+
 ## All commits
 
 | Commit ID   | Description                                                                                           |
@@ -119,6 +127,33 @@
 - Removed deprecated Microsoft.AspNetCore.Mvc package (functionality included with framework)
 - Note: Package KubernetesClient 15.0.1 has a known moderate severity vulnerability (GHSA-w7r3-mgwf-4mqq). Consider updating this package as a next step.
 
+## Docker and CI/CD Configuration Updates
+
+### Dockerfile (Root)
+
+Updated Docker base images from .NET 8.0 to .NET 10.0:
+- **Base image**: `mcr.microsoft.com/dotnet/aspnet:8.0` → `mcr.microsoft.com/dotnet/aspnet:10.0`
+- **Build image**: `mcr.microsoft.com/dotnet/sdk:8.0` → `mcr.microsoft.com/dotnet/sdk:10.0`
+
+This ensures the API container runs on the .NET 10 runtime and builds using the .NET 10 SDK.
+
+### WorkerServiceBilling/Dockerfile
+
+Updated Docker base images from .NET 8.0 to .NET 10.0:
+- **Base image**: `mcr.microsoft.com/dotnet/runtime:8.0` → `mcr.microsoft.com/dotnet/runtime:10.0`
+- **Build image**: `mcr.microsoft.com/dotnet/sdk:8.0` → `mcr.microsoft.com/dotnet/sdk:10.0`
+
+This ensures the Worker Service container runs on the .NET 10 runtime.
+
+### .github/workflows/main.yml
+
+Updated GitHub Actions workflow to use .NET 10:
+- **dotnet-version**: `8.0.x` → `10.0.x`
+
+This ensures the CI/CD pipeline builds, tests, and deploys using the .NET 10 SDK.
+
+**Important**: When deploying to AWS ECS, ensure the ECS task definitions are updated to use the new Docker images built with .NET 10.
+
 ## Important Notes
 
 ### Pomelo.EntityFrameworkCore.MySql Compatibility
@@ -132,12 +167,24 @@ The Pomelo.EntityFrameworkCore.MySql package remains at version 9.0.0 as there i
 
 The KubernetesClient package (version 15.0.1) in Poliedro.Billing.Api has a known moderate severity vulnerability. Consider updating this package to a newer, secure version as a follow-up action.
 
+### Docker Image Availability
+
+The .NET 10 Docker images used in the Dockerfiles are:
+- `mcr.microsoft.com/dotnet/aspnet:10.0` - ASP.NET Core runtime
+- `mcr.microsoft.com/dotnet/runtime:10.0` - .NET runtime
+- `mcr.microsoft.com/dotnet/sdk:10.0` - .NET SDK
+
+These images are official Microsoft images and are available on Microsoft Container Registry (MCR).
+
 ## Next steps
 
 1. **Test the application thoroughly** to ensure all functionality works correctly with .NET 10
 2. **Update KubernetesClient package** to address the security vulnerability
-3. **Monitor for Pomelo.EntityFrameworkCore.MySql updates** that support EF Core 10.0.0 to eliminate compatibility warnings
-4. **Review and update other outdated packages** (e.g., PDFsharp 6.1.1 → 6.2.3)
-5. **Run all unit tests** to validate the upgrade
-6. **Update deployment configurations** to use .NET 10 runtime
-7. **Update CI/CD pipelines** to use .NET 10 SDK
+3. **Test Docker builds locally** before pushing to ensure containers build successfully with .NET 10
+4. **Update ECS Task Definitions** in AWS to reference the new Docker images with .NET 10
+5. **Monitor for Pomelo.EntityFrameworkCore.MySql updates** that support EF Core 10.0.0 to eliminate compatibility warnings
+6. **Review and update other outdated packages** (e.g., PDFsharp 6.1.1 → 6.2.3)
+7. **Run all unit tests** to validate the upgrade
+8. **Test the CI/CD pipeline** to ensure it works correctly with .NET 10 SDK
+9. **Update any environment variables or configuration** in AWS ECS/ECR that reference .NET 8
+10. **Monitor the first deployment** to production carefully to catch any runtime issues

--- a/.github/upgrades/dotnet-upgrade-report.md
+++ b/.github/upgrades/dotnet-upgrade-report.md
@@ -1,0 +1,143 @@
+# .NET 10 Upgrade Report
+
+## Project target framework modifications
+
+| Project name                                                    | Old Target Framework | New Target Framework | Commits                                           |
+|:----------------------------------------------------------------|:--------------------:|:--------------------:|:--------------------------------------------------|
+| Poliedro.Billing.Domain                                         | net8.0               | net10.0              | 7ccbbbcb, 1785d6f5                                |
+| Poliedro.Billing.Application                                    | net8.0               | net10.0              | 0c45d6e3                                          |
+| Poliedro.Billing.Infraestructure.Persistence.Mysql              | net8.0               | net10.0              | a49c79df, a158beaf                                |
+| Poliedro.Billing.Infraestructure.External.TNS                   | net8.0               | net10.0              | 3d805178, ce8f08fc                                |
+| Poliedro.Billing.Infraestructure.External.Plemsi                | net8.0               | net10.0              | f87d8b52                                          |
+| Poliedro.Billing.Infraestructure.External.Siigo                 | net8.0               | net10.0              | 168e4723                                          |
+| Poliedro.Billing.Domain.Test                                    | net8.0               | net10.0              | 57ebdce2                                          |
+| Poliedro.Billing.Api.Tests                                      | net8.0               | net10.0              | 05ec7f58                                          |
+| Poliedro.Billing.Api                                            | net8.0               | net10.0              | 44015f72                                          |
+
+## NuGet Packages
+
+| Package Name                                        | Old Version    | New Version | Commits                                           |
+|:----------------------------------------------------|:--------------:|:-----------:|:--------------------------------------------------|
+| FluentValidation.AspNetCore                         | 11.3.0         | 11.3.1      | ecf1f65e                                          |
+| Microsoft.AspNetCore.Mvc                            | 2.2.0          | Removed     | e139246d, ad3ccf64, 4f271483, e4d47199, 21947f63 |
+| Microsoft.EntityFrameworkCore                       | 8.0.1          | 10.0.0      | 4f271483                                          |
+| Microsoft.EntityFrameworkCore.Tools                 | 8.0.1, 8.0.6   | 10.0.0      | 4f271483, ecf1f65e                                |
+| Microsoft.Extensions.Configuration                  | 8.0.0, 9.0.0   | 10.0.0      | e4d47199, 21ee36c9, 21947f63                      |
+| Microsoft.Extensions.Configuration.Abstractions     | 9.0.0          | 10.0.0      | e139246d                                          |
+| Microsoft.Extensions.DependencyInjection.Abstractions | 8.0.1, 8.0.6 | 10.0.0      | ad3ccf64, 21ee36c9, ecf1f65e                      |
+| Newtonsoft.Json                                     | 13.0.1         | 13.0.4      | 21ee36c9                                          |
+
+## All commits
+
+| Commit ID   | Description                                                                                           |
+|:------------|:------------------------------------------------------------------------------------------------------|
+| 22b82b43    | Commit upgrade plan                                                                                   |
+| e139246d    | Update dependencies in Poliedro.Billing.Domain.csproj                                                 |
+| 7ccbbbcb    | Update target framework to net10.0 in Domain.csproj                                                   |
+| 1785d6f5    | Removed unused Newtonsoft.Json using directive                                                        |
+| 0c45d6e3    | Update target framework to net10.0 in Application.csproj                                              |
+| ad3ccf64    | Update dependencies in Poliedro.Billing.Application.csproj                                            |
+| a49c79df    | Update target framework to net10.0 in Mysql.csproj                                                    |
+| 4f271483    | Update EF Core packages to v10 in Mysql.csproj                                                        |
+| 5cf8b73c    | Update dependencies in Mysql.csproj                                                                   |
+| a158beaf    | Store final changes for Poliedro.Billing.Infraestructure.Persistence.Mysql                           |
+| 3d805178    | Update target framework to net10.0 in TNS.csproj                                                      |
+| e4d47199    | Update dependencies in Poliedro.Billing.Infraestructure.External.TNS.csproj                           |
+| 631bf470    | Removed unused Newtonsoft.Json using directive in SettingsService.cs                                  |
+| ce8f08fc    | Store final changes for Poliedro.Billing.Infraestructure.External.TNS                                |
+| 986bfead    | Update dependencies in Plemsi.csproj                                                                  |
+| 21ee36c9    | Update NuGet package versions in Plemsi.csproj                                                        |
+| f87d8b52    | Update target framework to net10.0 in Plemsi.csproj                                                   |
+| 21947f63    | Update package references in Siigo.csproj                                                             |
+| 168e4723    | Update target framework to net10.0 in Siigo.csproj                                                    |
+| bde9537e    | Replace Newtonsoft.Json with System.Text.Json in SiigoDomainService.cs                                |
+| 57ebdce2    | Update target framework in Poliedro.Billing.Domain.Test.csproj                                        |
+| 05ec7f58    | Update target framework in Poliedro.Billing.Api.Tests.csproj                                          |
+| 44015f72    | Update target framework to net10.0 in Poliedro.Billing.Api.csproj                                     |
+| dd10d3e8    | Update Poliedro.Billing.Api.csproj dependencies                                                       |
+| ecf1f65e    | Update package versions in Poliedro.Billing.Api.csproj                                                |
+
+## Project feature upgrades
+
+### Poliedro.Billing.Domain
+
+- Updated target framework from net8.0 to net10.0
+- Upgraded Microsoft.Extensions.Configuration.Abstractions to version 10.0.0
+- Removed deprecated Microsoft.AspNetCore.Mvc package
+- Removed unused Newtonsoft.Json using directives from ApiResponse.cs
+
+### Poliedro.Billing.Application
+
+- Updated target framework from net8.0 to net10.0
+- Upgraded Microsoft.Extensions.DependencyInjection.Abstractions to version 10.0.0
+- Removed deprecated Microsoft.AspNetCore.Mvc package
+
+### Poliedro.Billing.Infraestructure.Persistence.Mysql
+
+- Updated target framework from net8.0 to net10.0
+- Upgraded Microsoft.EntityFrameworkCore and Microsoft.EntityFrameworkCore.Tools to version 10.0.0
+- Added Newtonsoft.Json version 13.0.4 package reference
+- Removed deprecated Microsoft.AspNetCore.Mvc package
+- Note: Pomelo.EntityFrameworkCore.MySql remains at version 9.0.0 as version 10.0.0 is not yet available. This causes a compatibility warning (NU1608) with EntityFrameworkCore.Relational 10.0.0, but the project compiles successfully.
+
+### Poliedro.Billing.Infraestructure.External.TNS
+
+- Updated target framework from net8.0 to net10.0
+- Upgraded Microsoft.Extensions.Configuration to version 10.0.0
+- Added Newtonsoft.Json version 13.0.4 package reference
+- Removed deprecated Microsoft.AspNetCore.Mvc package
+- Removed unused Newtonsoft.Json using directives from SettingsService.cs
+
+### Poliedro.Billing.Infraestructure.External.Plemsi
+
+- Updated target framework from net8.0 to net10.0
+- Upgraded Microsoft.Extensions.Configuration to version 10.0.0
+- Upgraded Microsoft.Extensions.DependencyInjection.Abstractions to version 10.0.0
+- Upgraded Newtonsoft.Json from version 13.0.1 to 13.0.4
+
+### Poliedro.Billing.Infraestructure.External.Siigo
+
+- Updated target framework from net8.0 to net10.0
+- Upgraded Microsoft.Extensions.Configuration to version 10.0.0
+- Removed deprecated Microsoft.AspNetCore.Mvc package
+- Replaced Newtonsoft.Json with System.Text.Json in SiigoDomainService.cs for better performance and .NET 10 compatibility
+
+### Poliedro.Billing.Domain.Test
+
+- Updated target framework from net8.0 to net10.0
+
+### Poliedro.Billing.Api.Tests
+
+- Updated target framework from net8.0 to net10.0
+
+### Poliedro.Billing.Api
+
+- Updated target framework from net8.0 to net10.0
+- Upgraded FluentValidation.AspNetCore from version 11.3.0 to 11.3.1
+- Upgraded Microsoft.EntityFrameworkCore.Tools to version 10.0.0
+- Upgraded Microsoft.Extensions.DependencyInjection.Abstractions to version 10.0.0
+- Removed deprecated Microsoft.AspNetCore.Mvc package (functionality included with framework)
+- Note: Package KubernetesClient 15.0.1 has a known moderate severity vulnerability (GHSA-w7r3-mgwf-4mqq). Consider updating this package as a next step.
+
+## Important Notes
+
+### Pomelo.EntityFrameworkCore.MySql Compatibility
+
+The Pomelo.EntityFrameworkCore.MySql package remains at version 9.0.0 as there is currently no version 10.0.0 available. This causes compatibility warnings (NU1608) with Microsoft.EntityFrameworkCore.Relational 10.0.0, but:
+- All projects compile successfully
+- The warnings do not prevent the application from running
+- Monitor for Pomelo updates that support EF Core 10.0.0
+
+### Security Vulnerability
+
+The KubernetesClient package (version 15.0.1) in Poliedro.Billing.Api has a known moderate severity vulnerability. Consider updating this package to a newer, secure version as a follow-up action.
+
+## Next steps
+
+1. **Test the application thoroughly** to ensure all functionality works correctly with .NET 10
+2. **Update KubernetesClient package** to address the security vulnerability
+3. **Monitor for Pomelo.EntityFrameworkCore.MySql updates** that support EF Core 10.0.0 to eliminate compatibility warnings
+4. **Review and update other outdated packages** (e.g., PDFsharp 6.1.1 → 6.2.3)
+5. **Run all unit tests** to validate the upgrade
+6. **Update deployment configurations** to use .NET 10 runtime
+7. **Update CI/CD pipelines** to use .NET 10 SDK

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Set up .NET SDK
         uses: actions/setup-dotnet@v2
         with:
-          dotnet-version: '8.0.x'
+          dotnet-version: '10.0.x'
           
       - name: SonarCloud Scan
         uses: SonarSource/sonarcloud-github-action@v2

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
-﻿FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS base
+﻿FROM mcr.microsoft.com/dotnet/aspnet:10.0 AS base
 USER app
 WORKDIR /app
 EXPOSE 8080
 EXPOSE 8081
 
-FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
 ARG BUILD_CONFIGURATION=Release
 WORKDIR /src
 COPY ["Poliedro.Billing.Api/Poliedro.Billing.Api.csproj", "Poliedro.Billing.Api/"]

--- a/Poliedro.Billing.Api.Tests/Poliedro.Billing.Api.Tests.csproj
+++ b/Poliedro.Billing.Api.Tests/Poliedro.Billing.Api.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 

--- a/Poliedro.Billing.Api/Poliedro.Billing.Api.csproj
+++ b/Poliedro.Billing.Api/Poliedro.Billing.Api.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>

--- a/Poliedro.Billing.Api/Poliedro.Billing.Api.csproj
+++ b/Poliedro.Billing.Api/Poliedro.Billing.Api.csproj
@@ -15,13 +15,12 @@
     <PackageReference Include="AspNetCore.HealthChecks.UI.Core" Version="9.0.0" />
     <PackageReference Include="AspNetCore.HealthChecks.UI.InMemory.Storage" Version="9.0.0" />
     <PackageReference Include="AspNetCore.HealthChecks.UI.MySql.Storage" Version="9.0.0" />
-    <PackageReference Include="FluentValidation.AspNetCore" Version="11.3.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.2.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="8.0.6">
+    <PackageReference Include="FluentValidation.AspNetCore" Version="11.3.1" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="10.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.6" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.6.2" />
     <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="6.6.2" />
   </ItemGroup>

--- a/Poliedro.Billing.Api/Poliedro.Billing.Api.csproj
+++ b/Poliedro.Billing.Api/Poliedro.Billing.Api.csproj
@@ -16,13 +16,12 @@
     <PackageReference Include="AspNetCore.HealthChecks.UI.InMemory.Storage" Version="9.0.0" />
     <PackageReference Include="AspNetCore.HealthChecks.UI.MySql.Storage" Version="9.0.0" />
     <PackageReference Include="FluentValidation.AspNetCore" Version="11.3.1" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="10.0.0">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="9.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.6.2" />
     <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="6.6.2" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.0" />
   </ItemGroup>
 
   <ItemGroup>
@@ -30,6 +29,7 @@
     <ProjectReference Include="..\Poliedro.Billing.Domain\Poliedro.Billing.Domain.csproj" />
     <ProjectReference Include="..\Poliedro.Billing.Infraestructure.External.Plemsi\Poliedro.Billing.Infraestructure.External.Plemsi.csproj" />
     <ProjectReference Include="..\Poliedro.Billing.Infraestructure.External.TNS\Poliedro.Billing.Infraestructure.External.TNS.csproj" />
+    <PackageReference Include="KubernetesClient" Version="15.0.1" />
     <ProjectReference Include="..\Poliedro.Billing.Infraestructure.External.Siigo\Poliedro.Billing.Infraestructure.External.Siigo.csproj" />
     <ProjectReference Include="..\Poliedro.Billing.Infraestructure.Persistence.Mysql\Poliedro.Billing.Infraestructure.Persistence.Mysql.csproj" />
   </ItemGroup>

--- a/Poliedro.Billing.Api/Poliedro.Billing.Api.csproj
+++ b/Poliedro.Billing.Api/Poliedro.Billing.Api.csproj
@@ -20,9 +20,9 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.6.2" />
     <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="6.6.2" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Poliedro.Billing.Application/Poliedro.Billing.Application.csproj
+++ b/Poliedro.Billing.Application/Poliedro.Billing.Application.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/Poliedro.Billing.Application/Poliedro.Billing.Application.csproj
+++ b/Poliedro.Billing.Application/Poliedro.Billing.Application.csproj
@@ -23,8 +23,7 @@
     <PackageReference Include="AutoMapper" Version="13.0.1" />
     <PackageReference Include="FluentValidation" Version="11.11.0" />
     <PackageReference Include="MediatR" Version="12.4.1" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.1" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Poliedro.Billing.Domain.Test/Poliedro.Billing.Domain.Test.csproj
+++ b/Poliedro.Billing.Domain.Test/Poliedro.Billing.Domain.Test.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 

--- a/Poliedro.Billing.Domain/Client/DomainService/IClientCreateService.cs
+++ b/Poliedro.Billing.Domain/Client/DomainService/IClientCreateService.cs
@@ -1,0 +1,10 @@
+using Poliedro.Billing.Domain.Client.Entities;
+using Poliedro.Billing.Domain.Common.Results;
+using Poliedro.Billing.Domain.Common.Results.Errors;
+
+namespace Poliedro.Billing.Domain.Client.DomainService;
+
+public interface IClientCreateService
+{
+    Task<Result<VoidResult, Error>> CreateAsync(ClientEntity clientBillingElectronicEntity, CancellationToken cancellationToken);
+}

--- a/Poliedro.Billing.Domain/Client/DomainService/IClientDeleteService.cs
+++ b/Poliedro.Billing.Domain/Client/DomainService/IClientDeleteService.cs
@@ -1,0 +1,9 @@
+using Poliedro.Billing.Domain.Common.Results;
+using Poliedro.Billing.Domain.Common.Results.Errors;
+
+namespace Poliedro.Billing.Domain.Client.DomainService;
+
+public interface IClientDeleteService
+{
+    Task<Result<VoidResult, Error>> DeleteAsync(int id, CancellationToken cancellationToken);
+}

--- a/Poliedro.Billing.Domain/Client/DomainService/IClientExistsService.cs
+++ b/Poliedro.Billing.Domain/Client/DomainService/IClientExistsService.cs
@@ -1,0 +1,6 @@
+namespace Poliedro.Billing.Domain.Client.DomainService;
+
+public interface IClientExistsService
+{
+    Task<bool> EntityExists(int id, CancellationToken cancellationToken);
+}

--- a/Poliedro.Billing.Domain/Client/DomainService/IClientGetAllService.cs
+++ b/Poliedro.Billing.Domain/Client/DomainService/IClientGetAllService.cs
@@ -1,0 +1,10 @@
+using Poliedro.Billing.Domain.Client.Entities;
+using Poliedro.Billing.Domain.Common.Results;
+using Poliedro.Billing.Domain.Common.Results.Errors;
+
+namespace Poliedro.Billing.Domain.Client.DomainService;
+
+public interface IClientGetAllService
+{
+    Task<Result<IEnumerable<ClientEntity>, Error>> GetAllAsync(CancellationToken cancellationToken);
+}

--- a/Poliedro.Billing.Domain/Client/DomainService/IClientGetByIdService.cs
+++ b/Poliedro.Billing.Domain/Client/DomainService/IClientGetByIdService.cs
@@ -1,0 +1,11 @@
+using Poliedro.Billing.Domain.Client.Entities;
+using Poliedro.Billing.Domain.Common.Results;
+using Poliedro.Billing.Domain.Common.Results.Errors;
+
+namespace Poliedro.Billing.Domain.Client.DomainService;
+
+public interface IClientGetByIdService
+{
+    Task<Result<ClientEntity, Error>> GetByIdAsync(int id, CancellationToken cancellationToken);
+    Task<Result<ClientEntity, Error>> GetByIdAsync(string apiKey, CancellationToken cancellationToken);
+}

--- a/Poliedro.Billing.Domain/Client/DomainService/IClientGetByTokenService.cs
+++ b/Poliedro.Billing.Domain/Client/DomainService/IClientGetByTokenService.cs
@@ -1,0 +1,10 @@
+using Poliedro.Billing.Domain.Client.Entities;
+using Poliedro.Billing.Domain.Common.Results;
+using Poliedro.Billing.Domain.Common.Results.Errors;
+
+namespace Poliedro.Billing.Domain.Client.DomainService;
+
+public interface IClientGetByTokenService
+{
+    Task<Result<ClientEntity, Error>> GetByTokenAsync(string token, CancellationToken cancellationToken);
+}

--- a/Poliedro.Billing.Domain/Client/DomainService/IClientUpdateService.cs
+++ b/Poliedro.Billing.Domain/Client/DomainService/IClientUpdateService.cs
@@ -1,0 +1,10 @@
+using Poliedro.Billing.Domain.Client.Entities;
+using Poliedro.Billing.Domain.Common.Results;
+using Poliedro.Billing.Domain.Common.Results.Errors;
+
+namespace Poliedro.Billing.Domain.Client.DomainService;
+
+public interface IClientUpdateService
+{
+    Task<Result<VoidResult, Error>> UpdateAsync(ClientEntity clientBillingElectronicEntity, CancellationToken cancellationToken);
+}

--- a/Poliedro.Billing.Domain/GetInvoice/Entities/ApiResponse.cs
+++ b/Poliedro.Billing.Domain/GetInvoice/Entities/ApiResponse.cs
@@ -1,5 +1,4 @@
 ﻿using System.Text.Json.Serialization;
-using Newtonsoft.Json;
 
 namespace Poliedro.Billing.Domain.GetInvoice.Entities;
 

--- a/Poliedro.Billing.Domain/Poliedro.Billing.Domain.csproj
+++ b/Poliedro.Billing.Domain/Poliedro.Billing.Domain.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/Poliedro.Billing.Domain/Poliedro.Billing.Domain.csproj
+++ b/Poliedro.Billing.Domain/Poliedro.Billing.Domain.csproj
@@ -9,8 +9,7 @@
   <ItemGroup>
     <PackageReference Include="FluentValidation" Version="11.11.0" />
     <PackageReference Include="MediatR" Version="12.4.1" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="9.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.0" />
     <PackageReference Include="PDFsharp" Version="6.1.1" />
   </ItemGroup>
 

--- a/Poliedro.Billing.Domain/Resolution/DomainService/IDianResolutionCreateService.cs
+++ b/Poliedro.Billing.Domain/Resolution/DomainService/IDianResolutionCreateService.cs
@@ -1,0 +1,10 @@
+using Poliedro.Billing.Domain.Common.Results;
+using Poliedro.Billing.Domain.Common.Results.Errors;
+using Poliedro.Billing.Domain.Resolution.Entities;
+
+namespace Poliedro.Billing.Domain.Resolution.DomainService;
+
+public interface IDianResolutionCreateService
+{
+    Task<Result<VoidResult, Error>> CreateAsync(DianResolutionEntity dianResolutionEntity, CancellationToken cancellationToken);
+}

--- a/Poliedro.Billing.Domain/Resolution/DomainService/IDianResolutionDeleteService.cs
+++ b/Poliedro.Billing.Domain/Resolution/DomainService/IDianResolutionDeleteService.cs
@@ -1,0 +1,10 @@
+using Poliedro.Billing.Domain.Common.Results;
+using Poliedro.Billing.Domain.Common.Results.Errors;
+using Poliedro.Billing.Domain.Resolution.Entities;
+
+namespace Poliedro.Billing.Domain.Resolution.DomainService;
+
+public interface IDianResolutionDeleteService
+{
+    Task<Result<VoidResult, Error>> DeleteAsync(DianResolutionEntity dianResolutionEntity, CancellationToken cancellationToken);
+}

--- a/Poliedro.Billing.Domain/Resolution/DomainService/IDianResolutionExistsService.cs
+++ b/Poliedro.Billing.Domain/Resolution/DomainService/IDianResolutionExistsService.cs
@@ -1,0 +1,6 @@
+namespace Poliedro.Billing.Domain.Resolution.DomainService;
+
+public interface IDianResolutionExistsService
+{
+    Task<bool> EntityExists(int resolutionId, CancellationToken cancellationToken);
+}

--- a/Poliedro.Billing.Domain/Resolution/DomainService/IDianResolutionGetAllService.cs
+++ b/Poliedro.Billing.Domain/Resolution/DomainService/IDianResolutionGetAllService.cs
@@ -1,0 +1,10 @@
+using Poliedro.Billing.Domain.Common.Results;
+using Poliedro.Billing.Domain.Common.Results.Errors;
+using Poliedro.Billing.Domain.Resolution.Entities;
+
+namespace Poliedro.Billing.Domain.Resolution.DomainService;
+
+public interface IDianResolutionGetAllService
+{
+    Task<Result<IEnumerable<DianResolutionEntity>, Error>> GetAllAsync(CancellationToken cancellationToken);
+}

--- a/Poliedro.Billing.Domain/Resolution/DomainService/IDianResolutionGetByIdService.cs
+++ b/Poliedro.Billing.Domain/Resolution/DomainService/IDianResolutionGetByIdService.cs
@@ -1,0 +1,10 @@
+using Poliedro.Billing.Domain.Common.Results;
+using Poliedro.Billing.Domain.Common.Results.Errors;
+using Poliedro.Billing.Domain.Resolution.Entities;
+
+namespace Poliedro.Billing.Domain.Resolution.DomainService;
+
+public interface IDianResolutionGetByIdService
+{
+    Task<Result<DianResolutionEntity, Error>> GetByIdAsync(int id, CancellationToken cancellationToken);
+}

--- a/Poliedro.Billing.Domain/Resolution/DomainService/IDianResolutionUpdateService.cs
+++ b/Poliedro.Billing.Domain/Resolution/DomainService/IDianResolutionUpdateService.cs
@@ -1,0 +1,10 @@
+using Poliedro.Billing.Domain.Common.Results;
+using Poliedro.Billing.Domain.Common.Results.Errors;
+using Poliedro.Billing.Domain.Resolution.Entities;
+
+namespace Poliedro.Billing.Domain.Resolution.DomainService;
+
+public interface IDianResolutionUpdateService
+{
+    Task<Result<VoidResult, Error>> UpdateAsync(DianResolutionEntity dianResolutionEntity, CancellationToken cancellationToken);
+}

--- a/Poliedro.Billing.Domain/Server/DomainService/IServerCreateService.cs
+++ b/Poliedro.Billing.Domain/Server/DomainService/IServerCreateService.cs
@@ -1,0 +1,10 @@
+using Poliedro.Billing.Domain.Common.Results;
+using Poliedro.Billing.Domain.Common.Results.Errors;
+using Poliedro.Billing.Domain.Server.Entities;
+
+namespace Poliedro.Billing.Domain.Server.DomainService;
+
+public interface IServerCreateService
+{
+    Task<Result<VoidResult, Error>> CreateAsync(ServerEntity serverEntity);
+}

--- a/Poliedro.Billing.Domain/Server/DomainService/IServerExistsService.cs
+++ b/Poliedro.Billing.Domain/Server/DomainService/IServerExistsService.cs
@@ -1,0 +1,6 @@
+namespace Poliedro.Billing.Domain.Server.DomainService;
+
+public interface IServerExistsService
+{
+    Task<bool> EntityExists(int id);
+}

--- a/Poliedro.Billing.Domain/Server/DomainService/IServerGetAllService.cs
+++ b/Poliedro.Billing.Domain/Server/DomainService/IServerGetAllService.cs
@@ -1,0 +1,9 @@
+using Poliedro.Billing.Domain.Common.Pagination;
+using Poliedro.Billing.Domain.Server.Entities;
+
+namespace Poliedro.Billing.Domain.Server.DomainService;
+
+public interface IServerGetAllService
+{
+    Task<IEnumerable<ServerEntity>> GetAllAsync(PaginationParams paginationParams);
+}

--- a/Poliedro.Billing.Domain/Server/DomainService/IServerGetByIdService.cs
+++ b/Poliedro.Billing.Domain/Server/DomainService/IServerGetByIdService.cs
@@ -1,0 +1,10 @@
+using Poliedro.Billing.Domain.Common.Results;
+using Poliedro.Billing.Domain.Common.Results.Errors;
+using Poliedro.Billing.Domain.Server.Entities;
+
+namespace Poliedro.Billing.Domain.Server.DomainService;
+
+public interface IServerGetByIdService
+{
+    Task<Result<ServerEntity, Error>> GetByIdAsync(int id);
+}

--- a/Poliedro.Billing.Domain/Server/DomainService/IServerUpdateService.cs
+++ b/Poliedro.Billing.Domain/Server/DomainService/IServerUpdateService.cs
@@ -1,0 +1,10 @@
+using Poliedro.Billing.Domain.Common.Results;
+using Poliedro.Billing.Domain.Common.Results.Errors;
+using Poliedro.Billing.Domain.Server.Entities;
+
+namespace Poliedro.Billing.Domain.Server.DomainService;
+
+public interface IServerUpdateService
+{
+    Task<Result<VoidResult, Error>> UpdateAsync(ServerEntity serverEntity);
+}

--- a/Poliedro.Billing.Infraestructure.External.Plemsi/Poliedro.Billing.Infraestructure.External.Plemsi.csproj
+++ b/Poliedro.Billing.Infraestructure.External.Plemsi/Poliedro.Billing.Infraestructure.External.Plemsi.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/Poliedro.Billing.Infraestructure.External.Plemsi/Poliedro.Billing.Infraestructure.External.Plemsi.csproj
+++ b/Poliedro.Billing.Infraestructure.External.Plemsi/Poliedro.Billing.Infraestructure.External.Plemsi.csproj
@@ -13,10 +13,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="9.0.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.0" />
     <PackageReference Include="MySqlConnector" Version="2.3.5" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Poliedro.Billing.Infraestructure.External.Plemsi/Poliedro.Billing.Infraestructure.External.Plemsi.csproj
+++ b/Poliedro.Billing.Infraestructure.External.Plemsi/Poliedro.Billing.Infraestructure.External.Plemsi.csproj
@@ -17,7 +17,7 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.0" />
     <PackageReference Include="MySqlConnector" Version="2.4.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="9.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Poliedro.Billing.Infraestructure.External.Plemsi/Poliedro.Billing.Infraestructure.External.Plemsi.csproj
+++ b/Poliedro.Billing.Infraestructure.External.Plemsi/Poliedro.Billing.Infraestructure.External.Plemsi.csproj
@@ -15,8 +15,9 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.0" />
-    <PackageReference Include="MySqlConnector" Version="2.3.5" />
+    <PackageReference Include="MySqlConnector" Version="2.4.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Poliedro.Billing.Infraestructure.External.Siigo/DomainServices/SiigoDomainService.cs
+++ b/Poliedro.Billing.Infraestructure.External.Siigo/DomainServices/SiigoDomainService.cs
@@ -1,4 +1,4 @@
-﻿using Newtonsoft.Json;
+﻿using System.Text.Json;
 using Poliedro.Billing.Domain.Common.Results;
 using Poliedro.Billing.Domain.Common.Results.Errors;
 using Poliedro.Billing.Domain.Siigo.DomainServices;
@@ -27,7 +27,7 @@ namespace Poliedro.Billing.Infraestructure.External.Siigo.DomainServices
 
             foreach (var item in request)
             {
-                string jsonContent = JsonConvert.SerializeObject(item);
+                string jsonContent = JsonSerializer.Serialize(item);
 
                 StringContent stringContent = new StringContent(jsonContent, Encoding.UTF8, config.mediaType);
                 using var client = new HttpClient();
@@ -50,7 +50,7 @@ namespace Poliedro.Billing.Infraestructure.External.Siigo.DomainServices
                 if (response.IsSuccessStatusCode)
                 {
                     string jsonResponse = await response.Content.ReadAsStringAsync();
-                    ApiRestSuccessResponseSiigo responseApi = JsonConvert.DeserializeObject<ApiRestSuccessResponseSiigo>(jsonResponse);
+                    ApiRestSuccessResponseSiigo responseApi = JsonSerializer.Deserialize<ApiRestSuccessResponseSiigo>(jsonResponse);
 
                     if (responseApi is not null)
                     {
@@ -66,7 +66,7 @@ namespace Poliedro.Billing.Infraestructure.External.Siigo.DomainServices
                 else
                 {
                     string jsonResponse = await response.Content.ReadAsStringAsync();
-                    ApiRestErrorResponseSiigo responseApi = JsonConvert.DeserializeObject<ApiRestErrorResponseSiigo>(jsonResponse);
+                    ApiRestErrorResponseSiigo responseApi = JsonSerializer.Deserialize<ApiRestErrorResponseSiigo>(jsonResponse);
                     responseSiigo.Status = false;
                     responseSiigo.Message = jsonResponse;
                     responseSiigo.Data.Add(responseApi);

--- a/Poliedro.Billing.Infraestructure.External.Siigo/Poliedro.Billing.Infraestructure.External.Siigo.csproj
+++ b/Poliedro.Billing.Infraestructure.External.Siigo/Poliedro.Billing.Infraestructure.External.Siigo.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/Poliedro.Billing.Infraestructure.External.Siigo/Poliedro.Billing.Infraestructure.External.Siigo.csproj
+++ b/Poliedro.Billing.Infraestructure.External.Siigo/Poliedro.Billing.Infraestructure.External.Siigo.csproj
@@ -7,8 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.0" />
   </ItemGroup>
   
   <ItemGroup>

--- a/Poliedro.Billing.Infraestructure.External.TNS/DomainServices/TNSDomainService.cs
+++ b/Poliedro.Billing.Infraestructure.External.TNS/DomainServices/TNSDomainService.cs
@@ -1,4 +1,4 @@
-﻿using Newtonsoft.Json;
+using Newtonsoft.Json;
 using Poliedro.Billing.Domain.Common.Results;
 using Poliedro.Billing.Domain.Common.Results.Errors;
 using Poliedro.Billing.Domain.TNS.DomainServices;

--- a/Poliedro.Billing.Infraestructure.External.TNS/Poliedro.Billing.Infraestructure.External.TNS.csproj
+++ b/Poliedro.Billing.Infraestructure.External.TNS/Poliedro.Billing.Infraestructure.External.TNS.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/Poliedro.Billing.Infraestructure.External.TNS/Poliedro.Billing.Infraestructure.External.TNS.csproj
+++ b/Poliedro.Billing.Infraestructure.External.TNS/Poliedro.Billing.Infraestructure.External.TNS.csproj
@@ -8,6 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Poliedro.Billing.Infraestructure.External.TNS/Poliedro.Billing.Infraestructure.External.TNS.csproj
+++ b/Poliedro.Billing.Infraestructure.External.TNS/Poliedro.Billing.Infraestructure.External.TNS.csproj
@@ -7,8 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Poliedro.Billing.Infraestructure.External.TNS/Services/Imp/SettingsService.cs
+++ b/Poliedro.Billing.Infraestructure.External.TNS/Services/Imp/SettingsService.cs
@@ -1,5 +1,4 @@
 ﻿using Microsoft.Extensions.Configuration;
-using Newtonsoft.Json;
 using Poliedro.Billing.Infraestructure.External.TNS.ConfigModels;
 
 namespace Poliedro.Billing.Infraestructure.External.TNS.Services.Imp

--- a/Poliedro.Billing.Infraestructure.Persistence.Mysql/Client/DomainService/Impl/ClientBillingDomainService.cs
+++ b/Poliedro.Billing.Infraestructure.Persistence.Mysql/Client/DomainService/Impl/ClientBillingDomainService.cs
@@ -1,101 +1,36 @@
-﻿using Microsoft.EntityFrameworkCore;
-using Poliedro.Billing.Application.Client.Errors;
-using Poliedro.Billing.Domain.Client.DomainService;
+﻿using Poliedro.Billing.Domain.Client.DomainService;
 using Poliedro.Billing.Domain.Client.Entities;
 using Poliedro.Billing.Domain.Common.Results;
 using Poliedro.Billing.Domain.Common.Results.Errors;
-using Poliedro.Billing.Infraestructure.Persistence.Mysql.Context;
 
 namespace Poliedro.Billing.Infraestructure.Persistence.Mysql.Client.DomainService.Impl;
 
-public class ClientBillingDomainService(DataBaseContext context) : IClientDomainService
+public class ClientBillingDomainService(
+    IClientCreateService createService,
+    IClientUpdateService updateService,
+    IClientGetAllService getAllService,
+    IClientGetByIdService getByIdService,
+    IClientGetByTokenService getByTokenService,
+    IClientDeleteService deleteService) : IClientDomainService
 {
-    public async Task<Result<VoidResult, Error>> CreateAsync(ClientEntity clientBillingElectronicEntity, CancellationToken cancellationToken)
-    {
-        await context.ClientBillingElectronic.AddAsync(clientBillingElectronicEntity, cancellationToken);
-        var result = await context.SaveChangesAsync() > 0;
-        if (!result)
-            return ClientBillingElectronicErrorBuilder.ClientBillingCreationException();
+    public Task<Result<VoidResult, Error>> CreateAsync(ClientEntity clientBillingElectronicEntity, CancellationToken cancellationToken)
+        => createService.CreateAsync(clientBillingElectronicEntity, cancellationToken);
 
-        return VoidResult.Instance;
-    }
+    public Task<Result<VoidResult, Error>> UpdateAsync(ClientEntity clientBillingElectronicEntity, CancellationToken cancellationToken)
+        => updateService.UpdateAsync(clientBillingElectronicEntity, cancellationToken);
 
-    public async Task<Result<VoidResult, Error>> UpdateAsync(ClientEntity clientBillingElectronicEntity, CancellationToken cancellationToken)
-    {
-        if (!await EntityExists(clientBillingElectronicEntity.ClientBillingElectronicId, cancellationToken))
-            return ClientBillingElectronicErrorBuilder.ClientBillingNotFoundException(clientBillingElectronicEntity.ClientBillingElectronicId);
+    public Task<Result<IEnumerable<ClientEntity>, Error>> GetAllAsync(CancellationToken cancellationToken)
+        => getAllService.GetAllAsync(cancellationToken);
 
-        context.ClientBillingElectronic.Update(clientBillingElectronicEntity);
-        var result = await context.SaveChangesAsync() > 0;
-        if (!result)
-            return ClientBillingElectronicErrorBuilder.ClientBillingUpdateException(clientBillingElectronicEntity.ClientBillingElectronicId);
+    public Task<Result<ClientEntity, Error>> GetByIdAsync(int id, CancellationToken cancellationToken)
+        => getByIdService.GetByIdAsync(id, cancellationToken);
 
-        return VoidResult.Instance;
-    }
+    public Task<Result<ClientEntity, Error>> GetByIdAsync(string Apikey, CancellationToken cancellationToken)
+        => getByIdService.GetByIdAsync(Apikey, cancellationToken);
 
-    public async Task<Result<IEnumerable<ClientEntity>, Error>> GetAllAsync(CancellationToken cancellationToken)
-    {
-        var entities = await context.ClientBillingElectronic
-        .Include(c => c.DianResolution)
-        .Include(c => c.Server)
-        .Where(c => c.Active == true)
-        .ToListAsync(cancellationToken);
+    public Task<Result<ClientEntity, Error>> GetByTokenAsync(string token, CancellationToken cancellationToken)
+        => getByTokenService.GetByTokenAsync(token, cancellationToken);
 
-        if (entities.Count == 0)
-            return ClientBillingElectronicErrorBuilder.NoClientBillingRecordsFoundException();
-
-        return entities;
-    }
-
-    public async Task<Result<ClientEntity, Error>> GetByIdAsync(int id, CancellationToken cancellationToken)
-    {
-        if (!await EntityExists(id, cancellationToken))
-            return ClientBillingElectronicErrorBuilder.ClientBillingNotFoundException(id);
-
-        return await context.ClientBillingElectronic
-            .Include(c => c.DianResolution)
-            .Include(c => c.Server)
-            
-            .FirstAsync(c => c.ClientBillingElectronicId == id);
-    }
-
-    public async Task<Result<ClientEntity, Error>> GetByTokenAsync(string token, CancellationToken cancellationToken)
-    {
-    
-        return await context.ClientBillingElectronic
-            .Include(c => c.Server)
-            .FirstAsync(c => c.ApiKey == token);
-    }
-
-
-
-    public async Task<Result<VoidResult, Error>> DeleteAsync(int id, CancellationToken cancellationToken)
-    {
-        var entity = await context.ClientBillingElectronic.FirstOrDefaultAsync(x => x.ClientBillingElectronicId == id);
-        if (entity == null)
-            return ClientBillingElectronicErrorBuilder.ClientBillingNotFoundException(id);
-
-        context.ClientBillingElectronic.Remove(entity);
-        var result = await context.SaveChangesAsync() > 0;
-        if (!result)
-            return ClientBillingElectronicErrorBuilder.ClientBillingDeletionException(id);
-
-        return VoidResult.Instance;
-    }
-
-    private async Task<bool> EntityExists(int id, CancellationToken cancellationToken)
-    {
-        return await context.ClientBillingElectronic
-            .AsNoTracking()
-            .AnyAsync(c => c.ClientBillingElectronicId == id, cancellationToken);
-    }
-
-    public async Task<Result<ClientEntity, Error>> GetByIdAsync(string Apikey, CancellationToken cancellationToken)
-    {
-        return await context.ClientBillingElectronic
-            .Include(c => c.DianResolution)
-            .Include(c => c.Server)
-            .Where(c => c.Active == true)
-            .FirstAsync(c => c.ApiKey == Apikey);
-    }
+    public Task<Result<VoidResult, Error>> DeleteAsync(int id, CancellationToken cancellationToken)
+        => deleteService.DeleteAsync(id, cancellationToken);
 }

--- a/Poliedro.Billing.Infraestructure.Persistence.Mysql/Client/DomainService/Impl/ClientCreateService.cs
+++ b/Poliedro.Billing.Infraestructure.Persistence.Mysql/Client/DomainService/Impl/ClientCreateService.cs
@@ -1,0 +1,21 @@
+using Poliedro.Billing.Application.Client.Errors;
+using Poliedro.Billing.Domain.Client.DomainService;
+using Poliedro.Billing.Domain.Client.Entities;
+using Poliedro.Billing.Domain.Common.Results;
+using Poliedro.Billing.Domain.Common.Results.Errors;
+using Poliedro.Billing.Infraestructure.Persistence.Mysql.Context;
+
+namespace Poliedro.Billing.Infraestructure.Persistence.Mysql.Client.DomainService.Impl;
+
+public class ClientCreateService(DataBaseContext context) : IClientCreateService
+{
+    public async Task<Result<VoidResult, Error>> CreateAsync(ClientEntity clientBillingElectronicEntity, CancellationToken cancellationToken)
+    {
+        await context.ClientBillingElectronic.AddAsync(clientBillingElectronicEntity, cancellationToken);
+        var result = await context.SaveChangesAsync(cancellationToken) > 0;
+        if (!result)
+            return ClientBillingElectronicErrorBuilder.ClientBillingCreationException();
+
+        return VoidResult.Instance;
+    }
+}

--- a/Poliedro.Billing.Infraestructure.Persistence.Mysql/Client/DomainService/Impl/ClientDeleteService.cs
+++ b/Poliedro.Billing.Infraestructure.Persistence.Mysql/Client/DomainService/Impl/ClientDeleteService.cs
@@ -1,0 +1,25 @@
+using Microsoft.EntityFrameworkCore;
+using Poliedro.Billing.Application.Client.Errors;
+using Poliedro.Billing.Domain.Client.DomainService;
+using Poliedro.Billing.Domain.Common.Results;
+using Poliedro.Billing.Domain.Common.Results.Errors;
+using Poliedro.Billing.Infraestructure.Persistence.Mysql.Context;
+
+namespace Poliedro.Billing.Infraestructure.Persistence.Mysql.Client.DomainService.Impl;
+
+public class ClientDeleteService(DataBaseContext context) : IClientDeleteService
+{
+    public async Task<Result<VoidResult, Error>> DeleteAsync(int id, CancellationToken cancellationToken)
+    {
+        var entity = await context.ClientBillingElectronic.FirstOrDefaultAsync(x => x.ClientBillingElectronicId == id, cancellationToken);
+        if (entity == null)
+            return ClientBillingElectronicErrorBuilder.ClientBillingNotFoundException(id);
+
+        context.ClientBillingElectronic.Remove(entity);
+        var result = await context.SaveChangesAsync(cancellationToken) > 0;
+        if (!result)
+            return ClientBillingElectronicErrorBuilder.ClientBillingDeletionException(id);
+
+        return VoidResult.Instance;
+    }
+}

--- a/Poliedro.Billing.Infraestructure.Persistence.Mysql/Client/DomainService/Impl/ClientExistsService.cs
+++ b/Poliedro.Billing.Infraestructure.Persistence.Mysql/Client/DomainService/Impl/ClientExistsService.cs
@@ -1,0 +1,15 @@
+using Microsoft.EntityFrameworkCore;
+using Poliedro.Billing.Domain.Client.DomainService;
+using Poliedro.Billing.Infraestructure.Persistence.Mysql.Context;
+
+namespace Poliedro.Billing.Infraestructure.Persistence.Mysql.Client.DomainService.Impl;
+
+public class ClientExistsService(DataBaseContext context) : IClientExistsService
+{
+    public async Task<bool> EntityExists(int id, CancellationToken cancellationToken)
+    {
+        return await context.ClientBillingElectronic
+            .AsNoTracking()
+            .AnyAsync(c => c.ClientBillingElectronicId == id, cancellationToken);
+    }
+}

--- a/Poliedro.Billing.Infraestructure.Persistence.Mysql/Client/DomainService/Impl/ClientGetAllService.cs
+++ b/Poliedro.Billing.Infraestructure.Persistence.Mysql/Client/DomainService/Impl/ClientGetAllService.cs
@@ -1,0 +1,26 @@
+using Microsoft.EntityFrameworkCore;
+using Poliedro.Billing.Application.Client.Errors;
+using Poliedro.Billing.Domain.Client.DomainService;
+using Poliedro.Billing.Domain.Client.Entities;
+using Poliedro.Billing.Domain.Common.Results;
+using Poliedro.Billing.Domain.Common.Results.Errors;
+using Poliedro.Billing.Infraestructure.Persistence.Mysql.Context;
+
+namespace Poliedro.Billing.Infraestructure.Persistence.Mysql.Client.DomainService.Impl;
+
+public class ClientGetAllService(DataBaseContext context) : IClientGetAllService
+{
+    public async Task<Result<IEnumerable<ClientEntity>, Error>> GetAllAsync(CancellationToken cancellationToken)
+    {
+        var entities = await context.ClientBillingElectronic
+            .Include(c => c.DianResolution)
+            .Include(c => c.Server)
+            .Where(c => c.Active == true)
+            .ToListAsync(cancellationToken);
+
+        if (entities.Count == 0)
+            return ClientBillingElectronicErrorBuilder.NoClientBillingRecordsFoundException();
+
+        return entities;
+    }
+}

--- a/Poliedro.Billing.Infraestructure.Persistence.Mysql/Client/DomainService/Impl/ClientGetByIdService.cs
+++ b/Poliedro.Billing.Infraestructure.Persistence.Mysql/Client/DomainService/Impl/ClientGetByIdService.cs
@@ -1,0 +1,32 @@
+using Microsoft.EntityFrameworkCore;
+using Poliedro.Billing.Application.Client.Errors;
+using Poliedro.Billing.Domain.Client.DomainService;
+using Poliedro.Billing.Domain.Client.Entities;
+using Poliedro.Billing.Domain.Common.Results;
+using Poliedro.Billing.Domain.Common.Results.Errors;
+using Poliedro.Billing.Infraestructure.Persistence.Mysql.Context;
+
+namespace Poliedro.Billing.Infraestructure.Persistence.Mysql.Client.DomainService.Impl;
+
+public class ClientGetByIdService(DataBaseContext context, IClientExistsService existsService) : IClientGetByIdService
+{
+    public async Task<Result<ClientEntity, Error>> GetByIdAsync(int id, CancellationToken cancellationToken)
+    {
+        if (!await existsService.EntityExists(id, cancellationToken))
+            return ClientBillingElectronicErrorBuilder.ClientBillingNotFoundException(id);
+
+        return await context.ClientBillingElectronic
+            .Include(c => c.DianResolution)
+            .Include(c => c.Server)
+            .FirstAsync(c => c.ClientBillingElectronicId == id, cancellationToken);
+    }
+
+    public async Task<Result<ClientEntity, Error>> GetByIdAsync(string apiKey, CancellationToken cancellationToken)
+    {
+        return await context.ClientBillingElectronic
+            .Include(c => c.DianResolution)
+            .Include(c => c.Server)
+            .Where(c => c.Active == true)
+            .FirstAsync(c => c.ApiKey == apiKey, cancellationToken);
+    }
+}

--- a/Poliedro.Billing.Infraestructure.Persistence.Mysql/Client/DomainService/Impl/ClientGetByTokenService.cs
+++ b/Poliedro.Billing.Infraestructure.Persistence.Mysql/Client/DomainService/Impl/ClientGetByTokenService.cs
@@ -1,0 +1,18 @@
+using Microsoft.EntityFrameworkCore;
+using Poliedro.Billing.Domain.Client.DomainService;
+using Poliedro.Billing.Domain.Client.Entities;
+using Poliedro.Billing.Domain.Common.Results;
+using Poliedro.Billing.Domain.Common.Results.Errors;
+using Poliedro.Billing.Infraestructure.Persistence.Mysql.Context;
+
+namespace Poliedro.Billing.Infraestructure.Persistence.Mysql.Client.DomainService.Impl;
+
+public class ClientGetByTokenService(DataBaseContext context) : IClientGetByTokenService
+{
+    public async Task<Result<ClientEntity, Error>> GetByTokenAsync(string token, CancellationToken cancellationToken)
+    {
+        return await context.ClientBillingElectronic
+            .Include(c => c.Server)
+            .FirstAsync(c => c.ApiKey == token, cancellationToken);
+    }
+}

--- a/Poliedro.Billing.Infraestructure.Persistence.Mysql/Client/DomainService/Impl/ClientUpdateService.cs
+++ b/Poliedro.Billing.Infraestructure.Persistence.Mysql/Client/DomainService/Impl/ClientUpdateService.cs
@@ -1,0 +1,24 @@
+using Poliedro.Billing.Application.Client.Errors;
+using Poliedro.Billing.Domain.Client.DomainService;
+using Poliedro.Billing.Domain.Client.Entities;
+using Poliedro.Billing.Domain.Common.Results;
+using Poliedro.Billing.Domain.Common.Results.Errors;
+using Poliedro.Billing.Infraestructure.Persistence.Mysql.Context;
+
+namespace Poliedro.Billing.Infraestructure.Persistence.Mysql.Client.DomainService.Impl;
+
+public class ClientUpdateService(DataBaseContext context, IClientExistsService existsService) : IClientUpdateService
+{
+    public async Task<Result<VoidResult, Error>> UpdateAsync(ClientEntity clientBillingElectronicEntity, CancellationToken cancellationToken)
+    {
+        if (!await existsService.EntityExists(clientBillingElectronicEntity.ClientBillingElectronicId, cancellationToken))
+            return ClientBillingElectronicErrorBuilder.ClientBillingNotFoundException(clientBillingElectronicEntity.ClientBillingElectronicId);
+
+        context.ClientBillingElectronic.Update(clientBillingElectronicEntity);
+        var result = await context.SaveChangesAsync(cancellationToken) > 0;
+        if (!result)
+            return ClientBillingElectronicErrorBuilder.ClientBillingUpdateException(clientBillingElectronicEntity.ClientBillingElectronicId);
+
+        return VoidResult.Instance;
+    }
+}

--- a/Poliedro.Billing.Infraestructure.Persistence.Mysql/DependencyInjectionService.cs
+++ b/Poliedro.Billing.Infraestructure.Persistence.Mysql/DependencyInjectionService.cs
@@ -62,8 +62,17 @@ public static class DependencyInjectionService
         
         // Composite service that implements IDianResolutionDomainService
         services.AddScoped<IDianResolutionDomainService, DianResolutionDomainService>();
+
+        // Server services - specialized implementations
+        services.AddScoped<IServerExistsService, ServerExistsService>();
+        services.AddScoped<IServerCreateService, ServerCreateService>();
+        services.AddScoped<IServerUpdateService, ServerUpdateService>();
+        services.AddScoped<IServerGetAllService, ServerGetAllService>();
+        services.AddScoped<IServerGetByIdService, ServerGetByIdService>();
         
+        // Composite service that implements IServerDomainService
         services.AddScoped<IServerDomainService, ServerDomainService>();
+        
         services.AddTransient<IMessageProvider, MessageProvider>();
        
         services.AddTransient<IInvoicePosDomainService, InvoicePosDomainService>();

--- a/Poliedro.Billing.Infraestructure.Persistence.Mysql/DependencyInjectionService.cs
+++ b/Poliedro.Billing.Infraestructure.Persistence.Mysql/DependencyInjectionService.cs
@@ -29,7 +29,6 @@ using Poliedro.Billing.Domain.Common.Methods.Billing.Prepare.Plemsi.ElectronicBi
 
 
 
-
 namespace Poliedro.Billing.Infraestructure.Persistence.Mysql;
 
 public static class DependencyInjectionService
@@ -40,7 +39,19 @@ public static class DependencyInjectionService
         services.AddDbContext<DataBaseContext>(
             options => options.UseMySql(connectionString, ServerVersion.AutoDetect(connectionString)
         ));
+        
+        // Client services - specialized implementations
+        services.AddScoped<IClientExistsService, ClientExistsService>();
+        services.AddScoped<IClientCreateService, ClientCreateService>();
+        services.AddScoped<IClientUpdateService, ClientUpdateService>();
+        services.AddScoped<IClientGetAllService, ClientGetAllService>();
+        services.AddScoped<IClientGetByIdService, ClientGetByIdService>();
+        services.AddScoped<IClientGetByTokenService, ClientGetByTokenService>();
+        services.AddScoped<IClientDeleteService, ClientDeleteService>();
+        
+        // Composite service that implements IClientDomainService
         services.AddTransient<IClientDomainService, ClientBillingDomainService>();
+        
         services.AddScoped<IServerDomainService, ServerDomainService>();
 
         services.AddScoped<IDianResolutionDomainService, DianResolutionDomainService>();

--- a/Poliedro.Billing.Infraestructure.Persistence.Mysql/DependencyInjectionService.cs
+++ b/Poliedro.Billing.Infraestructure.Persistence.Mysql/DependencyInjectionService.cs
@@ -51,10 +51,19 @@ public static class DependencyInjectionService
         
         // Composite service that implements IClientDomainService
         services.AddTransient<IClientDomainService, ClientBillingDomainService>();
+
+        // DianResolution services - specialized implementations
+        services.AddScoped<IDianResolutionExistsService, DianResolutionExistsService>();
+        services.AddScoped<IDianResolutionCreateService, DianResolutionCreateService>();
+        services.AddScoped<IDianResolutionUpdateService, DianResolutionUpdateService>();
+        services.AddScoped<IDianResolutionDeleteService, DianResolutionDeleteService>();
+        services.AddScoped<IDianResolutionGetAllService, DianResolutionGetAllService>();
+        services.AddScoped<IDianResolutionGetByIdService, DianResolutionGetByIdService>();
+        
+        // Composite service that implements IDianResolutionDomainService
+        services.AddScoped<IDianResolutionDomainService, DianResolutionDomainService>();
         
         services.AddScoped<IServerDomainService, ServerDomainService>();
-
-        services.AddScoped<IDianResolutionDomainService, DianResolutionDomainService>();
         services.AddTransient<IMessageProvider, MessageProvider>();
        
         services.AddTransient<IInvoicePosDomainService, InvoicePosDomainService>();

--- a/Poliedro.Billing.Infraestructure.Persistence.Mysql/DianResolution/DomainService/Impl/DianResolutionCreateService.cs
+++ b/Poliedro.Billing.Infraestructure.Persistence.Mysql/DianResolution/DomainService/Impl/DianResolutionCreateService.cs
@@ -1,0 +1,21 @@
+using Poliedro.Billing.Application.DianResolution.Errors;
+using Poliedro.Billing.Domain.Common.Results;
+using Poliedro.Billing.Domain.Common.Results.Errors;
+using Poliedro.Billing.Domain.Resolution.DomainService;
+using Poliedro.Billing.Domain.Resolution.Entities;
+using Poliedro.Billing.Infraestructure.Persistence.Mysql.Context;
+
+namespace Poliedro.Billing.Infraestructure.Persistence.Mysql.DianResolution.DomainService.Impl;
+
+public class DianResolutionCreateService(DataBaseContext context) : IDianResolutionCreateService
+{
+    public async Task<Result<VoidResult, Error>> CreateAsync(DianResolutionEntity dianResolutionEntity, CancellationToken cancellationToken)
+    {
+        await context.DianResolution.AddAsync(dianResolutionEntity, cancellationToken);
+        var result = await context.SaveChangesAsync(cancellationToken) > 0;
+        if (!result)
+            return DianResolutionErrorBuilder.DianResolutionCreationException();
+
+        return VoidResult.Instance;
+    }
+}

--- a/Poliedro.Billing.Infraestructure.Persistence.Mysql/DianResolution/DomainService/Impl/DianResolutionDeleteService.cs
+++ b/Poliedro.Billing.Infraestructure.Persistence.Mysql/DianResolution/DomainService/Impl/DianResolutionDeleteService.cs
@@ -1,0 +1,26 @@
+using Microsoft.EntityFrameworkCore;
+using Poliedro.Billing.Application.DianResolution.Errors;
+using Poliedro.Billing.Domain.Common.Results;
+using Poliedro.Billing.Domain.Common.Results.Errors;
+using Poliedro.Billing.Domain.Resolution.DomainService;
+using Poliedro.Billing.Domain.Resolution.Entities;
+using Poliedro.Billing.Infraestructure.Persistence.Mysql.Context;
+
+namespace Poliedro.Billing.Infraestructure.Persistence.Mysql.DianResolution.DomainService.Impl;
+
+public class DianResolutionDeleteService(DataBaseContext context) : IDianResolutionDeleteService
+{
+    public async Task<Result<VoidResult, Error>> DeleteAsync(DianResolutionEntity dianResolutionEntity, CancellationToken cancellationToken)
+    {
+        var entity = await context.DianResolution.FirstOrDefaultAsync(x => x.ResolutionId == dianResolutionEntity.ResolutionId, cancellationToken);
+        if (entity == null)
+            return DianResolutionErrorBuilder.DianResolutionNotFoundException(dianResolutionEntity.ResolutionId);
+
+        context.DianResolution.Remove(entity);
+        var result = await context.SaveChangesAsync(cancellationToken) > 0;
+        if (!result)
+            return DianResolutionErrorBuilder.DianResolutionDeletionException(dianResolutionEntity.ResolutionId);
+
+        return VoidResult.Instance;
+    }
+}

--- a/Poliedro.Billing.Infraestructure.Persistence.Mysql/DianResolution/DomainService/Impl/DianResolutionDomainService.cs
+++ b/Poliedro.Billing.Infraestructure.Persistence.Mysql/DianResolution/DomainService/Impl/DianResolutionDomainService.cs
@@ -1,82 +1,29 @@
-﻿using Microsoft.EntityFrameworkCore;
-using Poliedro.Billing.Application.DianResolution.Errors;
-using Poliedro.Billing.Domain.Common.Results;
+﻿using Poliedro.Billing.Domain.Common.Results;
 using Poliedro.Billing.Domain.Common.Results.Errors;
 using Poliedro.Billing.Domain.Resolution.DomainService;
 using Poliedro.Billing.Domain.Resolution.Entities;
-using Poliedro.Billing.Infraestructure.Persistence.Mysql.Context;
 
 namespace Poliedro.Billing.Infraestructure.Persistence.Mysql.DianResolution.DomainService.Impl;
 
-public class DianResolutionDomainService(DataBaseContext context) : IDianResolutionDomainService
+public class DianResolutionDomainService(
+    IDianResolutionCreateService createService,
+    IDianResolutionUpdateService updateService,
+    IDianResolutionDeleteService deleteService,
+    IDianResolutionGetAllService getAllService,
+    IDianResolutionGetByIdService getByIdService) : IDianResolutionDomainService
 {
-    public async Task<Result<VoidResult, Error>> CreateAsync(DianResolutionEntity dianResolutionEntity, CancellationToken cancellationToken)
-    {
-        await context.DianResolution.AddAsync(dianResolutionEntity);
-        var result = await context.SaveChangesAsync() > 0;
-        if (!result)
-            return DianResolutionErrorBuilder.DianResolutionCreationException();
+    public Task<Result<VoidResult, Error>> CreateAsync(DianResolutionEntity dianResolutionEntity, CancellationToken cancellationToken)
+        => createService.CreateAsync(dianResolutionEntity, cancellationToken);
 
-        return VoidResult.Instance;
-    }
+    public Task<Result<VoidResult, Error>> UpdateAsync(DianResolutionEntity dianResolutionEntity, CancellationToken cancellationToken)
+        => updateService.UpdateAsync(dianResolutionEntity, cancellationToken);
 
-    public async Task<Result<VoidResult, Error>> UpdateAsync(DianResolutionEntity dianResolutionEntity, CancellationToken cancellationToken)
-    {
-        if (!await EntityExists(dianResolutionEntity.ResolutionId))
-            return DianResolutionErrorBuilder.DianResolutionUpdateException(dianResolutionEntity.ResolutionId);
+    public Task<Result<VoidResult, Error>> DeleteAsync(DianResolutionEntity dianResolutionEntity, CancellationToken cancellationToken)
+        => deleteService.DeleteAsync(dianResolutionEntity, cancellationToken);
 
-        context.DianResolution.Update(dianResolutionEntity);
-        var result = await context.SaveChangesAsync() > 0;
-        if (!result)
-            return DianResolutionErrorBuilder.DianResolutionUpdateException(dianResolutionEntity.ResolutionId);
+    public Task<Result<IEnumerable<DianResolutionEntity>, Error>> GetAllAsync(CancellationToken cancellationToken)
+        => getAllService.GetAllAsync(cancellationToken);
 
-        return VoidResult.Instance;
-    }
-
-    public async Task<Result<VoidResult, Error>> DeleteAsync(DianResolutionEntity dianResolutionEntity, CancellationToken cancellationToken)
-    {
-        var entity = await context.DianResolution.FirstOrDefaultAsync(x => x.ResolutionId == dianResolutionEntity.ResolutionId);
-        if (entity == null)
-            return DianResolutionErrorBuilder.DianResolutionNotFoundException(dianResolutionEntity.ResolutionId);
-
-        context.DianResolution.Remove(entity);
-        var result = await context.SaveChangesAsync() > 0;
-        if (!result)
-            return DianResolutionErrorBuilder.DianResolutionDeletionException(dianResolutionEntity.ResolutionId);
-
-        return VoidResult.Instance;
-    }
-
-    public async Task<Result<IEnumerable<DianResolutionEntity>, Error>> GetAllAsync(CancellationToken cancellationToken)
-    {
-        var entities = await context.DianResolution
-        .Include(c => c.clientsBillingElectronic)
-        .Where(c => c.Active == true)
-        .ToListAsync(cancellationToken);
-
-        if (entities.Count == 0)
-            return DianResolutionErrorBuilder.NoDianResolutionFoundException();
-
-        return entities;
-    }
-
-    public async Task<Result<DianResolutionEntity, Error>> GetByIdAsync(int id, CancellationToken cancellationToken)
-    {
-        var dianResolution = await context.DianResolution
-            .FindAsync(id, cancellationToken);
-        if (dianResolution != null)
-        {
-            return dianResolution;
-        }
-        return null;
-    }
-
-    private async Task<bool> EntityExists(int ResolutionId)
-    {
-        return await context.DianResolution
-            .AsNoTracking()
-            .AnyAsync(c => c.ResolutionId == ResolutionId);
-    }
-
-
+    public Task<Result<DianResolutionEntity, Error>> GetByIdAsync(int id, CancellationToken cancellationToken)
+        => getByIdService.GetByIdAsync(id, cancellationToken);
 }

--- a/Poliedro.Billing.Infraestructure.Persistence.Mysql/DianResolution/DomainService/Impl/DianResolutionExistsService.cs
+++ b/Poliedro.Billing.Infraestructure.Persistence.Mysql/DianResolution/DomainService/Impl/DianResolutionExistsService.cs
@@ -1,0 +1,15 @@
+using Microsoft.EntityFrameworkCore;
+using Poliedro.Billing.Domain.Resolution.DomainService;
+using Poliedro.Billing.Infraestructure.Persistence.Mysql.Context;
+
+namespace Poliedro.Billing.Infraestructure.Persistence.Mysql.DianResolution.DomainService.Impl;
+
+public class DianResolutionExistsService(DataBaseContext context) : IDianResolutionExistsService
+{
+    public async Task<bool> EntityExists(int resolutionId, CancellationToken cancellationToken)
+    {
+        return await context.DianResolution
+            .AsNoTracking()
+            .AnyAsync(c => c.ResolutionId == resolutionId, cancellationToken);
+    }
+}

--- a/Poliedro.Billing.Infraestructure.Persistence.Mysql/DianResolution/DomainService/Impl/DianResolutionGetAllService.cs
+++ b/Poliedro.Billing.Infraestructure.Persistence.Mysql/DianResolution/DomainService/Impl/DianResolutionGetAllService.cs
@@ -1,0 +1,25 @@
+using Microsoft.EntityFrameworkCore;
+using Poliedro.Billing.Application.DianResolution.Errors;
+using Poliedro.Billing.Domain.Common.Results;
+using Poliedro.Billing.Domain.Common.Results.Errors;
+using Poliedro.Billing.Domain.Resolution.DomainService;
+using Poliedro.Billing.Domain.Resolution.Entities;
+using Poliedro.Billing.Infraestructure.Persistence.Mysql.Context;
+
+namespace Poliedro.Billing.Infraestructure.Persistence.Mysql.DianResolution.DomainService.Impl;
+
+public class DianResolutionGetAllService(DataBaseContext context) : IDianResolutionGetAllService
+{
+    public async Task<Result<IEnumerable<DianResolutionEntity>, Error>> GetAllAsync(CancellationToken cancellationToken)
+    {
+        var entities = await context.DianResolution
+            .Include(c => c.clientsBillingElectronic)
+            .Where(c => c.Active == true)
+            .ToListAsync(cancellationToken);
+
+        if (entities.Count == 0)
+            return DianResolutionErrorBuilder.NoDianResolutionFoundException();
+
+        return entities;
+    }
+}

--- a/Poliedro.Billing.Infraestructure.Persistence.Mysql/DianResolution/DomainService/Impl/DianResolutionGetByIdService.cs
+++ b/Poliedro.Billing.Infraestructure.Persistence.Mysql/DianResolution/DomainService/Impl/DianResolutionGetByIdService.cs
@@ -1,0 +1,23 @@
+using Poliedro.Billing.Domain.Common.Results;
+using Poliedro.Billing.Domain.Common.Results.Errors;
+using Poliedro.Billing.Domain.Resolution.DomainService;
+using Poliedro.Billing.Domain.Resolution.Entities;
+using Poliedro.Billing.Infraestructure.Persistence.Mysql.Context;
+
+namespace Poliedro.Billing.Infraestructure.Persistence.Mysql.DianResolution.DomainService.Impl;
+
+public class DianResolutionGetByIdService(DataBaseContext context) : IDianResolutionGetByIdService
+{
+    public async Task<Result<DianResolutionEntity, Error>> GetByIdAsync(int id, CancellationToken cancellationToken)
+    {
+        var dianResolution = await context.DianResolution
+            .FindAsync([id], cancellationToken);
+        
+        if (dianResolution != null)
+        {
+            return dianResolution;
+        }
+        
+        return null!;
+    }
+}

--- a/Poliedro.Billing.Infraestructure.Persistence.Mysql/DianResolution/DomainService/Impl/DianResolutionUpdateService.cs
+++ b/Poliedro.Billing.Infraestructure.Persistence.Mysql/DianResolution/DomainService/Impl/DianResolutionUpdateService.cs
@@ -1,0 +1,24 @@
+using Poliedro.Billing.Application.DianResolution.Errors;
+using Poliedro.Billing.Domain.Common.Results;
+using Poliedro.Billing.Domain.Common.Results.Errors;
+using Poliedro.Billing.Domain.Resolution.DomainService;
+using Poliedro.Billing.Domain.Resolution.Entities;
+using Poliedro.Billing.Infraestructure.Persistence.Mysql.Context;
+
+namespace Poliedro.Billing.Infraestructure.Persistence.Mysql.DianResolution.DomainService.Impl;
+
+public class DianResolutionUpdateService(DataBaseContext context, IDianResolutionExistsService existsService) : IDianResolutionUpdateService
+{
+    public async Task<Result<VoidResult, Error>> UpdateAsync(DianResolutionEntity dianResolutionEntity, CancellationToken cancellationToken)
+    {
+        if (!await existsService.EntityExists(dianResolutionEntity.ResolutionId, cancellationToken))
+            return DianResolutionErrorBuilder.DianResolutionUpdateException(dianResolutionEntity.ResolutionId);
+
+        context.DianResolution.Update(dianResolutionEntity);
+        var result = await context.SaveChangesAsync(cancellationToken) > 0;
+        if (!result)
+            return DianResolutionErrorBuilder.DianResolutionUpdateException(dianResolutionEntity.ResolutionId);
+
+        return VoidResult.Instance;
+    }
+}

--- a/Poliedro.Billing.Infraestructure.Persistence.Mysql/Poliedro.Billing.Infraestructure.Persistence.Mysql.csproj
+++ b/Poliedro.Billing.Infraestructure.Persistence.Mysql/Poliedro.Billing.Infraestructure.Persistence.Mysql.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/Poliedro.Billing.Infraestructure.Persistence.Mysql/Poliedro.Billing.Infraestructure.Persistence.Mysql.csproj
+++ b/Poliedro.Billing.Infraestructure.Persistence.Mysql/Poliedro.Billing.Infraestructure.Persistence.Mysql.csproj
@@ -7,15 +7,14 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="10.0.0">
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="9.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageReference Include="PDFsharp" Version="6.1.1" />
     <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="9.0.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Poliedro.Billing.Infraestructure.Persistence.Mysql/Poliedro.Billing.Infraestructure.Persistence.Mysql.csproj
+++ b/Poliedro.Billing.Infraestructure.Persistence.Mysql/Poliedro.Billing.Infraestructure.Persistence.Mysql.csproj
@@ -7,9 +7,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.2.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.1" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="8.0.1">
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="10.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/Poliedro.Billing.Infraestructure.Persistence.Mysql/Poliedro.Billing.Infraestructure.Persistence.Mysql.csproj
+++ b/Poliedro.Billing.Infraestructure.Persistence.Mysql/Poliedro.Billing.Infraestructure.Persistence.Mysql.csproj
@@ -13,7 +13,8 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="PDFsharp" Version="6.1.1" />
-    <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="8.0.1" />
+    <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="9.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Poliedro.Billing.Infraestructure.Persistence.Mysql/Poliedro.Billing.Infraestructure.Persistence.Mysql.csproj
+++ b/Poliedro.Billing.Infraestructure.Persistence.Mysql/Poliedro.Billing.Infraestructure.Persistence.Mysql.csproj
@@ -12,6 +12,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageReference Include="PDFsharp" Version="6.1.1" />
     <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="9.0.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.0" />

--- a/Poliedro.Billing.Infraestructure.Persistence.Mysql/Server/DomainService/Impl/ServerCreateService.cs
+++ b/Poliedro.Billing.Infraestructure.Persistence.Mysql/Server/DomainService/Impl/ServerCreateService.cs
@@ -1,0 +1,21 @@
+using Poliedro.Billing.Application.Server.Errors;
+using Poliedro.Billing.Domain.Common.Results;
+using Poliedro.Billing.Domain.Common.Results.Errors;
+using Poliedro.Billing.Domain.Server.DomainService;
+using Poliedro.Billing.Domain.Server.Entities;
+using Poliedro.Billing.Infraestructure.Persistence.Mysql.Context;
+
+namespace Poliedro.Billing.Infraestructure.Persistence.Mysql.Server.DomainService.Impl;
+
+public class ServerCreateService(DataBaseContext context) : IServerCreateService
+{
+    public async Task<Result<VoidResult, Error>> CreateAsync(ServerEntity serverEntity)
+    {
+        await context.Server.AddAsync(serverEntity);
+        var result = await context.SaveChangesAsync() > 0;
+        if (!result)
+            return ServerErrorBuilder.ServerCreationException();
+
+        return VoidResult.Instance;
+    }
+}

--- a/Poliedro.Billing.Infraestructure.Persistence.Mysql/Server/DomainService/Impl/ServerDomainService.cs
+++ b/Poliedro.Billing.Infraestructure.Persistence.Mysql/Server/DomainService/Impl/ServerDomainService.cs
@@ -10,54 +10,21 @@ using Poliedro.Billing.Infraestructure.Persistence.Mysql.Context;
 
 namespace Poliedro.Billing.Infraestructure.Persistence.Mysql.Server.DomainService.Impl;
 
-public class ServerDomainService(DataBaseContext context) : IServerDomainService
+public class ServerDomainService(
+    IServerCreateService createService,
+    IServerUpdateService updateService,
+    IServerGetAllService getAllService,
+    IServerGetByIdService getByIdService) : IServerDomainService
 {
-    public async Task<IEnumerable<ServerEntity>> GetAllAsync(PaginationParams paginationParams)
-    {
-        var totalRows = await context.Server.CountAsync();
+    public Task<Result<VoidResult, Error>> CreateAsync(ServerEntity serverEntity)
+        => createService.CreateAsync(serverEntity);
 
-      return await context.Server
-            .Skip((paginationParams.PageNumber - 1) * paginationParams.PageSize)
-            .Take(paginationParams.PageSize)
-            .ToListAsync();
-    }
-    public async Task<Result<ServerEntity, Error>> GetByIdAsync(int id)
-    {
-        if (!await EntityExists(id))
-            return ServerErrorBuilder.ServerNotFoundException(id);
+    public Task<Result<VoidResult, Error>> UpdateAsync(ServerEntity serverEntity)
+        => updateService.UpdateAsync(serverEntity);
 
-        return await context.Server
-            .Include(c => c.clientsBillingElectronic)
-            .FirstAsync(c => c.ServerId == id);
-    }
+    public Task<IEnumerable<ServerEntity>> GetAllAsync(PaginationParams paginationParams)
+        => getAllService.GetAllAsync(paginationParams);
 
-    public async Task<Result<VoidResult, Error>> UpdateAsync(ServerEntity serverEntity)
-    {
-        if (!await EntityExists(serverEntity.ServerId))
-            return ServerErrorBuilder.ServerNotFoundException(serverEntity.ServerId);
-
-        context.Server.Update(serverEntity);
-
-        if (await context.SaveChangesAsync() <= 0)
-            return ServerErrorBuilder.ServerUpdateException();
-
-        return VoidResult.Instance;
-    }
-
-    public async Task<Result<VoidResult, Error>> CreateAsync(ServerEntity serverEntity)
-    {
-        await context.Server.AddAsync(serverEntity);
-        var result = await context.SaveChangesAsync() > 0;
-        if (!result)
-            return ServerErrorBuilder.ServerCreationException();
-
-        return VoidResult.Instance;
-    }
-
-    private async Task<bool> EntityExists(int id)
-    {
-        return await context.Server
-            .AsNoTracking()
-            .AnyAsync(c => c.ServerId == id);
-    }
+    public Task<Result<ServerEntity, Error>> GetByIdAsync(int id)
+        => getByIdService.GetByIdAsync(id);
 }

--- a/Poliedro.Billing.Infraestructure.Persistence.Mysql/Server/DomainService/Impl/ServerExistsService.cs
+++ b/Poliedro.Billing.Infraestructure.Persistence.Mysql/Server/DomainService/Impl/ServerExistsService.cs
@@ -1,0 +1,15 @@
+using Microsoft.EntityFrameworkCore;
+using Poliedro.Billing.Domain.Server.DomainService;
+using Poliedro.Billing.Infraestructure.Persistence.Mysql.Context;
+
+namespace Poliedro.Billing.Infraestructure.Persistence.Mysql.Server.DomainService.Impl;
+
+public class ServerExistsService(DataBaseContext context) : IServerExistsService
+{
+    public async Task<bool> EntityExists(int id)
+    {
+        return await context.Server
+            .AsNoTracking()
+            .AnyAsync(c => c.ServerId == id);
+    }
+}

--- a/Poliedro.Billing.Infraestructure.Persistence.Mysql/Server/DomainService/Impl/ServerGetAllService.cs
+++ b/Poliedro.Billing.Infraestructure.Persistence.Mysql/Server/DomainService/Impl/ServerGetAllService.cs
@@ -1,0 +1,18 @@
+using Microsoft.EntityFrameworkCore;
+using Poliedro.Billing.Domain.Common.Pagination;
+using Poliedro.Billing.Domain.Server.DomainService;
+using Poliedro.Billing.Domain.Server.Entities;
+using Poliedro.Billing.Infraestructure.Persistence.Mysql.Context;
+
+namespace Poliedro.Billing.Infraestructure.Persistence.Mysql.Server.DomainService.Impl;
+
+public class ServerGetAllService(DataBaseContext context) : IServerGetAllService
+{
+    public async Task<IEnumerable<ServerEntity>> GetAllAsync(PaginationParams paginationParams)
+    {
+        return await context.Server
+            .Skip((paginationParams.PageNumber - 1) * paginationParams.PageSize)
+            .Take(paginationParams.PageSize)
+            .ToListAsync();
+    }
+}

--- a/Poliedro.Billing.Infraestructure.Persistence.Mysql/Server/DomainService/Impl/ServerGetByIdService.cs
+++ b/Poliedro.Billing.Infraestructure.Persistence.Mysql/Server/DomainService/Impl/ServerGetByIdService.cs
@@ -1,0 +1,22 @@
+using Microsoft.EntityFrameworkCore;
+using Poliedro.Billing.Application.Server.Errors;
+using Poliedro.Billing.Domain.Common.Results;
+using Poliedro.Billing.Domain.Common.Results.Errors;
+using Poliedro.Billing.Domain.Server.DomainService;
+using Poliedro.Billing.Domain.Server.Entities;
+using Poliedro.Billing.Infraestructure.Persistence.Mysql.Context;
+
+namespace Poliedro.Billing.Infraestructure.Persistence.Mysql.Server.DomainService.Impl;
+
+public class ServerGetByIdService(DataBaseContext context, IServerExistsService existsService) : IServerGetByIdService
+{
+    public async Task<Result<ServerEntity, Error>> GetByIdAsync(int id)
+    {
+        if (!await existsService.EntityExists(id))
+            return ServerErrorBuilder.ServerNotFoundException(id);
+
+        return await context.Server
+            .Include(c => c.clientsBillingElectronic)
+            .FirstAsync(c => c.ServerId == id);
+    }
+}

--- a/Poliedro.Billing.Infraestructure.Persistence.Mysql/Server/DomainService/Impl/ServerUpdateService.cs
+++ b/Poliedro.Billing.Infraestructure.Persistence.Mysql/Server/DomainService/Impl/ServerUpdateService.cs
@@ -1,0 +1,24 @@
+using Poliedro.Billing.Application.Server.Errors;
+using Poliedro.Billing.Domain.Common.Results;
+using Poliedro.Billing.Domain.Common.Results.Errors;
+using Poliedro.Billing.Domain.Server.DomainService;
+using Poliedro.Billing.Domain.Server.Entities;
+using Poliedro.Billing.Infraestructure.Persistence.Mysql.Context;
+
+namespace Poliedro.Billing.Infraestructure.Persistence.Mysql.Server.DomainService.Impl;
+
+public class ServerUpdateService(DataBaseContext context, IServerExistsService existsService) : IServerUpdateService
+{
+    public async Task<Result<VoidResult, Error>> UpdateAsync(ServerEntity serverEntity)
+    {
+        if (!await existsService.EntityExists(serverEntity.ServerId))
+            return ServerErrorBuilder.ServerNotFoundException(serverEntity.ServerId);
+
+        context.Server.Update(serverEntity);
+
+        if (await context.SaveChangesAsync() <= 0)
+            return ServerErrorBuilder.ServerUpdateException();
+
+        return VoidResult.Instance;
+    }
+}

--- a/WorkerServiceBilling/Dockerfile
+++ b/WorkerServiceBilling/Dockerfile
@@ -1,10 +1,10 @@
 #See https://aka.ms/customizecontainer to learn how to customize your debug container and how Visual Studio uses this Dockerfile to build your images for faster debugging.
 
-FROM mcr.microsoft.com/dotnet/runtime:8.0 AS base
+FROM mcr.microsoft.com/dotnet/runtime:10.0 AS base
 USER app
 WORKDIR /app
 
-FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
 ARG BUILD_CONFIGURATION=Release
 WORKDIR /src
 COPY ["WorkerServiceBilling/WorkerServiceBilling.csproj", "WorkerServiceBilling/"]


### PR DESCRIPTION
## Summary by Sourcery

Upgrade the solution to .NET 10 while modularizing persistence domain services for clients, DIAN resolutions, and servers, and aligning external integrations with updated JSON and dependency versions.

New Features:
- Introduce granular domain service interfaces and implementations for client, DIAN resolution, and server CRUD and lookup operations.
- Add dedicated existence-check services for clients, DIAN resolutions, and servers to support reusable validation logic.

Enhancements:
- Refactor DianResolutionDomainService and ServerDomainService into thin orchestrators that delegate to specialized CRUD and query services registered in dependency injection.
- Register new client, DIAN resolution, and server service implementations in the persistence layer's dependency injection setup for clearer composition and testability.
- Replace Newtonsoft.Json with System.Text.Json in the Siigo integration for serialization and deserialization to align with modern .NET APIs and performance best practices.
- Remove unused Newtonsoft.Json references and usings where no longer needed to reduce dependencies and improve maintainability.

Build:
- Update all project files to target .NET 10 and bump related NuGet packages (EF Core, configuration, DI, validation, and JSON libraries) to versions compatible with .NET 10.

Documentation:
- Add .NET 10 upgrade plan and upgrade report documentation under .github/upgrades describing framework, package, and project-level changes.