### PR TITLE
Fixingpdfinvoice

### DIFF
--- a/Poliedro.Billing.Api/Endpoints/v1/PdfInvoice/PdfInvoiceEndpoints.cs
+++ b/Poliedro.Billing.Api/Endpoints/v1/PdfInvoice/PdfInvoiceEndpoints.cs
@@ -9,7 +9,7 @@ public static class PdfInvoiceEndpoints
 {
     public static RouteGroupBuilder MapPdfInvoiceEndpoints(this RouteGroupBuilder group)
     {
-        group.MapGet("/pdfinvoice/{id}", GetPdfInvoice)
+        group.MapGet("/pdfinvoice/pdf/{id}", GetPdfInvoice)
             .WithName("GetPdfInvoice")
             .WithTags("PdfInvoice")
             .WithSummary("Get PDF invoice")

--- a/Poliedro.Billing.Api/Endpoints/v1/PdfInvoice/PdfInvoiceEndpoints.cs
+++ b/Poliedro.Billing.Api/Endpoints/v1/PdfInvoice/PdfInvoiceEndpoints.cs
@@ -9,7 +9,7 @@ public static class PdfInvoiceEndpoints
 {
     public static RouteGroupBuilder MapPdfInvoiceEndpoints(this RouteGroupBuilder group)
     {
-        group.MapGet("/pdf/{id}", GetPdfInvoice)
+        group.MapGet("/pdfinvoice/{id}", GetPdfInvoice)
             .WithName("GetPdfInvoice")
             .WithTags("PdfInvoice")
             .WithSummary("Get PDF invoice")


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Change the PDF invoice GET endpoint URL from /pdf/{id} to /pdfinvoice/pdf/{id} to better reflect its context or avoid conflicts.