### PR TITLE
feat(billingPOS)

### DIFF
--- a/Poliedro.Billing.Application/Billing/Dtos/Plemsi/POS/ItemRequestPosDto.cs
+++ b/Poliedro.Billing.Application/Billing/Dtos/Plemsi/POS/ItemRequestPosDto.cs
@@ -3,8 +3,8 @@
 public record ItemRequestPosDto
 {
     public int unit_measure_id { get; init; }
-    public string invoiced_quantity { get; init; }
-    public string line_extension_amount { get; init; }
+    public double invoiced_quantity { get; init; }
+    public double line_extension_amount { get; init; }
     public bool free_of_charge_indicator { get; init; }
     public List<TaxTotalRequestPosDto> tax_totals { get; init; }
     public string description { get; init; }
@@ -12,6 +12,6 @@ public record ItemRequestPosDto
     public string code { get; init; }
     public int type_item_identification_id { get; init; }
     public string price_amount { get; init; }
-    public string base_quantity { get; init; }
+    public double base_quantity { get; init; }
 
 }

--- a/Poliedro.Billing.Application/Billing/Services/Selectors/Plemsi/PrepareBillingPOS.cs
+++ b/Poliedro.Billing.Application/Billing/Services/Selectors/Plemsi/PrepareBillingPOS.cs
@@ -77,8 +77,8 @@ public class PrepareBillingPOS(
                     var itemInvoice = new ItemFERetailEntity
                     {
                         unit_measure_id = 70,
-                        invoiced_quantity = item.InvoicedQuantity.ToString(),
-                        line_extension_amount = item.Subtotal.ToString(),
+                        invoiced_quantity = item.InvoicedQuantity,
+                        line_extension_amount = item.Subtotal,
                         free_of_charge_indicator = false,
                         tax_totals =[],
                         description = item.Description,
@@ -86,7 +86,7 @@ public class PrepareBillingPOS(
                         code = item.Code.ToString(),
                         type_item_identification_id = 4,
                         price_amount = item.PriceAmount.ToString(),
-                        base_quantity = item.InvoicedQuantity.ToString()
+                        base_quantity = item.InvoicedQuantity
                     };
                     itemsInvoiceResponse.Add(itemInvoice);
                 }

--- a/Poliedro.Billing.Domain/Billing/ItemPosEntity.cs
+++ b/Poliedro.Billing.Domain/Billing/ItemPosEntity.cs
@@ -8,9 +8,9 @@ public class ItemFERetailEntity
     [JsonPropertyName("unit_measure_id")]
     public int unit_measure_id { get; set; }
     [JsonPropertyName("invoiced_quantity")]
-    public string invoiced_quantity { get; set; }
+    public double invoiced_quantity { get; set; }
     [JsonPropertyName("line_extension_amount")]
-    public string line_extension_amount { get; set; }
+    public double line_extension_amount { get; set; }
     [JsonPropertyName("free_of_charge_indicator")]
     public bool free_of_charge_indicator { get; set; }
     [JsonPropertyName("tax_totals")]
@@ -26,5 +26,5 @@ public class ItemFERetailEntity
     [JsonPropertyName("price_amount")]
     public string price_amount { get; set; }
     [JsonPropertyName("base_quantity")]
-    public string base_quantity { get; set; }
+    public double base_quantity { get; set; }
 }

--- a/Poliedro.Billing.Domain/Billing/ItemsInvoiceEntity.cs
+++ b/Poliedro.Billing.Domain/Billing/ItemsInvoiceEntity.cs
@@ -5,8 +5,8 @@ public class ItemsInvoiceEntity
     public string Resolution { get; set; } = default!;
     public string Description { get; set; } = default!;
     public string Code { get; set; } = default!;
-    public decimal BaseQuantity { get; set; } = default!;
-    public decimal InvoicedQuantity { get; set; } = default!;
+    public double BaseQuantity { get; set; } = default!;
+    public double InvoicedQuantity { get; set; } = default!;
     public decimal PriceAmount { get; set; } = default!;
-    public decimal Subtotal { get; set; } = default!;
+    public double Subtotal { get; set; } = default!;
 }

--- a/Poliedro.Billing.Infraestructure.External.Plemsi/Adapter/POS/EDS/GetItemsInvoicePosAsync.cs
+++ b/Poliedro.Billing.Infraestructure.External.Plemsi/Adapter/POS/EDS/GetItemsInvoicePosAsync.cs
@@ -15,8 +15,8 @@ namespace Poliedro.Billing.Infraestructure.External.Plemsi.Adapter.POS.EDS
                 var itemInvoice = new ItemFERetailEntity
                 {
                     unit_measure_id = 70,
-                    invoiced_quantity = index.InvoicedQuantity.ToString(),
-                    line_extension_amount = index.Subtotal.ToString(),
+                    invoiced_quantity = index.InvoicedQuantity,
+                    line_extension_amount = index.Subtotal,
                     free_of_charge_indicator = false,
                     tax_totals =
                     [
@@ -27,7 +27,7 @@ namespace Poliedro.Billing.Infraestructure.External.Plemsi.Adapter.POS.EDS
                     code = index.Code,
                     type_item_identification_id = 4,
                     price_amount = index.PriceAmount.ToString(),
-                    base_quantity = index.InvoicedQuantity.ToString()
+                    base_quantity = index.InvoicedQuantity
                 };
                 itemsInvoiceResponse.Add(itemInvoice);
             }

--- a/Poliedro.Billing.Infraestructure.External.Plemsi/Adapter/POS/EDS/GetItemsPosAsync.cs
+++ b/Poliedro.Billing.Infraestructure.External.Plemsi/Adapter/POS/EDS/GetItemsPosAsync.cs
@@ -30,10 +30,10 @@ namespace Poliedro.Billing.Infraestructure.External.Plemsi.Adapter.POS.EDS
                                 Resolution = reader.GetString(0),
                                 Description = reader.GetString(1),
                                 Code = reader.GetString(2),
-                                BaseQuantity = reader.GetDecimal(3),
-                                InvoicedQuantity = reader.GetDecimal(4),
+                                BaseQuantity = reader.GetDouble(3),
+                                InvoicedQuantity = reader.GetDouble(4),
                                 PriceAmount = reader.GetDecimal(5),
-                                Subtotal = reader.GetDecimal(6)
+                                Subtotal = reader.GetDouble(6)
                             };
                             invoices.Add(invoice);
                         }


### PR DESCRIPTION
## Summary by Sourcery

Align POS billing item quantity and amount types to use numeric values instead of strings across DTOs, domain entities, and adapters.

Enhancements:
- Change invoiced quantity, line extension amount, and base quantity fields from string to double in POS item DTOs and entities.
- Update item invoice domain model to use double for quantity and subtotal values instead of decimal where appropriate.
- Adjust POS data access to read numeric quantities and subtotals as doubles and propagate them without string conversions in external adapter mappings.