### PR TITLE
feat(Correction when defining the 100% discount on items)

### DIFF
--- a/Poliedro.Billing.Application/Billing/AutoMappers/BillingAutoMapper.cs
+++ b/Poliedro.Billing.Application/Billing/AutoMappers/BillingAutoMapper.cs
@@ -78,6 +78,7 @@ public class BillingAutoMapper : Profile
         CreateMap<GeneralAllowanceEntity, GeneralAllowanceRequestFEDTO>()
             .ForMember(dest => dest.allowance_charge_reason, opt => opt.MapFrom(src => src.AllowanceChargeReason))
             .ForMember(dest => dest.allowance_percent, opt => opt.MapFrom(src => src.AllowancePercent))
+            .ForMember(dest => dest.multiplier_factor_numeric, opt => opt.MapFrom(src => src.MultiplierFactorNumeric))
             .ForMember(dest => dest.amount, opt => opt.MapFrom(src => src.Amount))
             .ForMember(dest => dest.base_amount, opt => opt.MapFrom(src => src.BaseAmount));
         CreateMap<ItemElectronicEntity, ItemElectronicRequestFEDTO>()

--- a/Poliedro.Billing.Application/Billing/Dtos/Plemsi/FE/GeneralAllowanceRequestFEDTO.cs
+++ b/Poliedro.Billing.Application/Billing/Dtos/Plemsi/FE/GeneralAllowanceRequestFEDTO.cs
@@ -3,6 +3,7 @@ public record GeneralAllowanceRequestFEDTO
 {
      public string? allowance_charge_reason {  get; init; }
      public double? allowance_percent { get; init; }
+     public decimal multiplier_factor_numeric { get; init; }
      public decimal amount { get; init; }
      public decimal base_amount { get; init; }
 }

--- a/Poliedro.Billing.Application/Billing/Services/Selectors/Plemsi/PrepareBillingFE.cs
+++ b/Poliedro.Billing.Application/Billing/Services/Selectors/Plemsi/PrepareBillingFE.cs
@@ -207,15 +207,19 @@ namespace Poliedro.Billing.Application.Billing.Services.Selectors.Plemsi
 
 
                         generalAllowances = globalDiscount > 0
-                            ? new List<GeneralAllowanceEntity> {
-                                new GeneralAllowanceEntity {
-                                    AllowanceChargeReason = "Commercial Discount",
-                                    AllowancePercent = roundedDiscountPercent,
-                                    Amount = Math.Round((decimal)globalDiscount, 2),
-                                    BaseAmount = (decimal)invoiceBaseTotal
-                                }
+                        ? new List<GeneralAllowanceEntity>
+                        {
+                            new GeneralAllowanceEntity
+                            {
+                                AllowanceChargeReason = "Commercial Discount",
+                                AllowancePercent = roundedDiscountPercent,
+                                MultiplierFactorNumeric = roundedDiscountPercent > 0 ? 1 : 0,
+                                Amount = Math.Round((decimal)globalDiscount, 2),
+                                BaseAmount = (decimal)invoiceBaseTotal
                             }
-                            : new List<GeneralAllowanceEntity>(),
+                        }
+                        : new List<GeneralAllowanceEntity>(),
+
 
                         items = invoice.ItemElectronicEntity,
                         resolution = clientInfo.ResolucionNumber,

--- a/Poliedro.Billing.Domain/Common/Methods/Billing/Prepare/Plemsi/ElectronicBilling/PrepareItemElectronic.cs
+++ b/Poliedro.Billing.Domain/Common/Methods/Billing/Prepare/Plemsi/ElectronicBilling/PrepareItemElectronic.cs
@@ -12,6 +12,49 @@ namespace Poliedro.Billing.Domain.Common.Methods.Billing.Prepare.Plemsi.Electron
             foreach (var item in items)
             {
 
+                bool isFreeItem =
+                    item.LineDiscountType == "percentage" &&
+                    item.LineDiscountAmount == 100;
+
+                if (isFreeItem)
+                {
+                    itemsInvoiceResponse.Add(new ItemElectronicEntity
+                    {
+                        UnitMeasureId = item.UnitMeasureId > 0 ? item.UnitMeasureId : 70,
+                        InvoicedQuantity = item.InvoicedQuantity,
+                        FreeOfChargeIndicator = true,
+
+                        LineExtensionAmount = 0,
+
+                        AllowanceCharges = new(),
+                        WithHoldingTaxTotal = new(),
+
+                        TaxTotals = new()
+                        {
+                            new TaxTotalEntity
+                            {
+                                TaxId = 1,         
+                                Percent = 0,
+                                TaxAmount = 0,
+                                TaxableAmount = 0
+                            }
+                        },
+
+                        Description = $"{item.Description} (ENTREGA GRATUITA)",
+                        Notes = string.IsNullOrWhiteSpace(item.Notes)
+                        ? "Description"
+                        : item.Notes,
+                        Code = item.Code,
+                        TypeItemIdentificationId = 1,
+
+                        
+                        PriceAmount = Math.Round((double)item.UnitPriceBeforeDiscount, 2),
+                        BaseQuantity = item.BaseQuantity
+                    });
+
+                    continue;
+                }
+
                 double TotalGross = (double)(item.UnitPriceBeforeDiscount * item.InvoicedQuantity);
 
                 double subtotal = item.UnitPrice * item.InvoicedQuantity;
@@ -34,7 +77,7 @@ namespace Poliedro.Billing.Domain.Common.Methods.Billing.Prepare.Plemsi.Electron
                     });
                 }
 
-                // Calculate tax with proper rounding
+                
                 double taxableAmount = Math.Round(item.UnitPrice * item.InvoicedQuantity, 2, MidpointRounding.AwayFromZero);
                 double taxAmount = Math.Round(taxableAmount * (item.Percent / 100), 2, MidpointRounding.AwayFromZero);
 
@@ -56,12 +99,14 @@ namespace Poliedro.Billing.Domain.Common.Methods.Billing.Prepare.Plemsi.Electron
                     UnitMeasureId = item.UnitMeasureId > 0 ? item.UnitMeasureId : 70,
                     LineExtensionAmount = taxableAmount,
                     InvoicedQuantity = item.InvoicedQuantity,
-                    FreeOfChargeIndicator = item.FreeOfChargeIndicator,
+                    FreeOfChargeIndicator  = false,
                     AllowanceCharges = allowanceCharges,
                     TaxTotals = taxTotals,
                     WithHoldingTaxTotal = [],
                     Description = $"{item.Description} {(item.TaxTotals?.FirstOrDefault()?.TaxAmount > 0 ? $"IVA {item.TaxTotals?.FirstOrDefault()?.TaxAmount}" : "")}",
-                    Notes = item.Notes,
+                    Notes = string.IsNullOrWhiteSpace(item.Notes)
+                    ? "Description"
+                    : item.Notes,
                     Code = item.Code,
                     TypeItemIdentificationId = 1,
                     PriceAmount = Math.Round(item.PriceAmount, 2, MidpointRounding.AwayFromZero),

--- a/Poliedro.Billing.Domain/FERetail/Entity/GeneralAllowanceEntity.cs
+++ b/Poliedro.Billing.Domain/FERetail/Entity/GeneralAllowanceEntity.cs
@@ -10,6 +10,9 @@ public class GeneralAllowanceEntity
     [JsonPropertyName("allowance_percent")]
     public double? AllowancePercent { get; set; }
 
+    [JsonPropertyName("multiplier_factor_numeric")]
+    public decimal MultiplierFactorNumeric { get; set; }
+
     [JsonPropertyName("amount")]
     public required decimal Amount { get; set; }
 


### PR DESCRIPTION
## Summary by Sourcery

Handle 100% line discount items as free-of-charge lines and enrich global allowance metadata for electronic billing exports.

New Features:
- Treat items with a 100% percentage line discount as free-of-charge invoice items with zero taxable amounts and taxes.
- Include a multiplier factor field on general allowances and propagate it through DTO mappings for FE requests.

Enhancements:
- Standardize default notes content for item lines when notes are missing or blank instead of passing through empty values.