### PR TITLE
Feature/deploy on premise

### DIFF
--- a/.github/workflows/deploy-onpremise.yml
+++ b/.github/workflows/deploy-onpremise.yml
@@ -18,14 +18,14 @@ jobs:
         with:
           dotnet-version: '10.0.x'
 
-      - name: SonarCloud Scan
-        uses: SonarSource/sonarcloud-github-action@v2
-        with:
-          args: >
-            -Dsonar.projectKey=PoliedroSoftware_backend-api-billing
-            -Dsonar.organization=poliedro-software-sonarqube
-        env:
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+      # - name: SonarCloud Scan
+      #   uses: SonarSource/sonarcloud-github-action@v2
+      #   with:
+      #     args: >
+      #       -Dsonar.projectKey=PoliedroSoftware_backend-api-billing
+      #       -Dsonar.organization=poliedro-software-sonarqube
+      #   env:
+      #     SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
 
 
       - name: Restore dependencies

--- a/.github/workflows/deploy-onpremise.yml
+++ b/.github/workflows/deploy-onpremise.yml
@@ -3,7 +3,7 @@ name: Build, Test, Deploy to On-Premise
 on:
   push:
     branches:
-      - main
+      - releasecandidate/v1.0.0
 
 jobs:
   build_and_deploy_onpremise:


### PR DESCRIPTION
## Summary by Sourcery

Update on-premise deployment workflow to target release candidate branch and temporarily disable SonarCloud scanning in the pipeline.

CI:
- Trigger on-premise deployment workflow on the releasecandidate/v1.0.0 branch instead of main.
- Comment out the SonarCloud scan step in the on-premise deployment GitHub Actions workflow.